### PR TITLE
Author and story tables

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/uwblueprint/shoe-project/config"
 	"github.com/uwblueprint/shoe-project/internal/database"
+	"github.com/uwblueprint/shoe-project/internal/database/migrations"
 	"github.com/uwblueprint/shoe-project/restapi"
 	"github.com/uwblueprint/shoe-project/server"
 	"go.uber.org/zap"
@@ -37,7 +38,18 @@ var (
 
 			db, err := database.Connect()
 			if err != nil {
-				logger.Fatalw("Failed to connect to databse", "Err", err)
+				logger.Fatalw("Failed to connect to database", "Err", err)
+			}
+
+			// initialize tables and seed the database (dev mode only)
+			if config.GetMode() == config.MODE_DEV {
+				if err := migrations.CreateTables(db); err != nil {
+					logger.Fatalw("Database table creation failed", "Err", err)
+				}
+
+				if err := migrations.Seed(db); err != nil {
+					logger.Fatalw("Database seed failed", "Err", err)
+				}
 			}
 
 			apiRouter, err := restapi.Router(db)

--- a/internal/database/migrations/migrations.go
+++ b/internal/database/migrations/migrations.go
@@ -1,0 +1,39 @@
+package migrations
+
+import (
+	"math/rand"
+	"strconv"
+	"time"
+
+	"github.com/uwblueprint/shoe-project/internal/database/models"
+	"gorm.io/gorm"
+)
+
+func CreateTables(db *gorm.DB) error {
+	return db.AutoMigrate(&models.Story{}, &models.Author{})
+}
+
+func Seed(db *gorm.DB) error {
+	rand.Seed(time.Now().Unix())
+	randNum := rand.Int()
+
+	seed := models.Author{
+		FirstName:     "Grace " + strconv.Itoa(randNum),
+		LastName:      "Hopper",
+		Bio:           "pioneer",
+		OriginCountry: "United States",
+		CurrentCity:   "Memory",
+		Stories: []models.Story{
+			{
+				Title:   "Test title",
+				Content: "sample text",
+			},
+			{
+				Title:   "Test title 2",
+				Content: "sample text 2",
+			},
+		},
+	}
+
+	return db.Create(&seed).Error
+}

--- a/internal/database/models/models.go
+++ b/internal/database/models/models.go
@@ -1,0 +1,23 @@
+package models
+
+import (
+	"gorm.io/gorm"
+)
+
+type Author struct {
+	gorm.Model
+	FirstName     string `gorm:"not null"`
+	LastName      string
+	Bio           string  `gorm:"type:text"`
+	OriginCountry string  `gorm:"not null"`
+	CurrentCity   string  `gorm:"not null"`
+	Stories       []Story `gorm:"foreignKey:AuthorID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
+}
+
+type Story struct {
+	gorm.Model
+	Title    string `gorm:"not null"`
+	Content  string `gorm:"type:text;not null"`
+	AuthorID uint
+	Author   Author
+}


### PR DESCRIPTION
Closes: #10 #21  (had to be done together, see `associations`)

Uses author and story GORM models to create (thru migrations) the test db tables whenever the server runs. 

- Associations are: `Story BELONGS TO Author` and `Author HAS MANY Story`

Differences from `Story` schema in #10 :
- Omitted `City` field : already exists in `Author`
- Omitted all multimedia fields : to be updated after #19 