### PR TITLE
Inserting authors should be unique

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -112,9 +112,8 @@ github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5m
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/websocket v1.0.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
-github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
 github.com/gorilla/websocket v1.0.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
-github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
+github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
 github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=

--- a/internal/database/models/models.go
+++ b/internal/database/models/models.go
@@ -1,26 +1,33 @@
 package models
 
 import (
+	"time"
+
 	"gorm.io/gorm"
 )
 
 type Author struct {
-	gorm.Model
-	FirstName     string  `gorm:"not null" json:"first_name"`
-	LastName      string  `json:"last_name"`
-	Bio           string  `gorm:"type:text" json:"bio"`
-	OriginCountry string  `gorm:"not null" json:"origin_country"`
-	Stories       []Story `gorm:"foreignKey:AuthorID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;" json:"stories,omitempty"`
+	ID            uint `gorm:"autoIncrement:true"`
+	CreatedAt     time.Time
+	UpdatedAt     time.Time
+	DeletedAt     gorm.DeletedAt `gorm:"index"`
+	FirstName     string         `gorm:"primaryKey;not null" json:"first_name"`
+	LastName      string         `gorm:"primaryKey" json:"last_name"`
+	Bio           string         `gorm:"type:text" json:"bio"`
+	OriginCountry string         `gorm:"primaryKey;not null" json:"origin_country"`
+	Stories       []Story        `gorm:"foreignKey:AuthorFirstName,AuthorLastName,AuthorCountry;references:FirstName,LastName,OriginCountry;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;" json:"stories,omitempty"`
 }
 
 type Story struct {
 	gorm.Model
-	Title       string  `gorm:"not null" json:"title"`
-	Content     string  `gorm:"type:text;not null" json:"content"`
-	CurrentCity string  `gorm:"not null" json:"current_city"`
-	Summary     string  `gorm:"type:text" json:"summary"`
-	Latitude    float64 `gorm:"not null" json:"latitude"`
-	Longitude   float64 `gorm:"not null" json:"longitude"`
-	AuthorID    uint    `json:"author_id"`
-	Author      Author  `json:"author"`
+	Title           string  `gorm:"not null" json:"title"`
+	Content         string  `gorm:"type:text;not null" json:"content"`
+	CurrentCity     string  `gorm:"not null" json:"current_city"`
+	Summary         string  `gorm:"type:text" json:"summary"`
+	Latitude        float64 `gorm:"not null" json:"latitude"`
+	Longitude       float64 `gorm:"not null" json:"longitude"`
+	AuthorFirstName string  `json:"author_first_name"`
+	AuthorLastName  string  `json:"author_last_name"`
+	AuthorCountry   string  `json:"author_country"`
+	Author          Author  `gorm:"foreignKey:AuthorFirstName,AuthorLastName,AuthorCountry;references:FirstName,LastName,OriginCountry" json:"author"`
 }

--- a/internal/database/models/models.go
+++ b/internal/database/models/models.go
@@ -7,7 +7,6 @@ import (
 )
 
 type Author struct {
-	ID            uint `gorm:"autoIncrement:true"`
 	CreatedAt     time.Time
 	UpdatedAt     time.Time
 	DeletedAt     gorm.DeletedAt `gorm:"index"`

--- a/restapi/endpoints_test.go
+++ b/restapi/endpoints_test.go
@@ -75,21 +75,25 @@ func (suite *endpointTestSuite) TestHealthCheck() {
 func (suite *endpointTestSuite) TestGetAllStories() {
 	json_story1 := []models.Story{
 		{
-			Title:       "The Little Prince",
-			Content:     "Children",
-			Summary:     "Summary1",
-			CurrentCity: "Toronto",
-			AuthorID:    1,
+			Title:           "The Little Prince",
+			Content:         "Children",
+			Summary:         "Summary1",
+			CurrentCity:     "Toronto",
+			AuthorFirstName: "Antoine",
+			AuthorLastName:  "dSE",
+			AuthorCountry:   "France",
 		},
 	}
 
 	json_story2 := []models.Story{
 		{
-			Title:       "Hitchhiker's Guide to the Galaxy",
-			Content:     "Fiction",
-			Summary:     "Summary2",
-			CurrentCity: "Toronto",
-			AuthorID:    2,
+			Title:           "Hitchhiker's Guide to the Galaxy",
+			Content:         "Fiction",
+			Summary:         "Summary2",
+			CurrentCity:     "Toronto",
+			AuthorFirstName: "Douglas",
+			AuthorLastName:  "Adams",
+			AuthorCountry:   "UK",
 		},
 	}
 
@@ -104,14 +108,18 @@ func (suite *endpointTestSuite) TestGetAllStories() {
 	mock := `{
 		"payload": [
 		{
-			"author_id": 1,
+			"author_first_name": "Antoine",
+			"author_last_name": "dSE",
+			"author_country": "France",
 			"content": "Children",
 			"title": "The Little Prince",
 			"summary": "Summary1",
 			"current_city": "Toronto"
 		},
 		{
-			"author_id": 2,
+			"author_first_name": "Douglas",
+			"author_last_name": "Adams",
+			"author_country": "UK",
 			"content": "Fiction",
 			"title": "Hitchhiker's Guide to the Galaxy",
 			"summary": "Summary2",
@@ -124,11 +132,18 @@ func (suite *endpointTestSuite) TestGetAllStories() {
 	//Verify response matches
 	response.Schema(mock)
 
+	response.Object().Value("payload").Array().Element(0).Object().Value("author_first_name").Equal("Antoine")
+	response.Object().Value("payload").Array().Element(0).Object().Value("author_last_name").Equal("dSE")
+	response.Object().Value("payload").Array().Element(0).Object().Value("author_country").Equal("France")
 	response.Object().Value("payload").Array().Element(0).Object().Value("ID").Equal(1)
 	response.Object().Value("payload").Array().Element(0).Object().Value("content").Equal("Children")
 	response.Object().Value("payload").Array().Element(0).Object().Value("title").Equal("The Little Prince")
 	response.Object().Value("payload").Array().Element(0).Object().Value("summary").Equal("Summary1")
 	response.Object().Value("payload").Array().Element(0).Object().Value("current_city").Equal("Toronto")
+
+	response.Object().Value("payload").Array().Element(1).Object().Value("author_first_name").Equal("Douglas")
+	response.Object().Value("payload").Array().Element(1).Object().Value("author_last_name").Equal("Adams")
+	response.Object().Value("payload").Array().Element(1).Object().Value("author_country").Equal("UK")
 	response.Object().Value("payload").Array().Element(1).Object().Value("ID").Equal(2)
 	response.Object().Value("payload").Array().Element(1).Object().Value("content").Equal("Fiction")
 	response.Object().Value("payload").Array().Element(1).Object().Value("title").Equal("Hitchhiker's Guide to the Galaxy")
@@ -160,9 +175,11 @@ func (suite *endpointTestSuite) TestCreateAuthor() {
 func (suite *endpointTestSuite) TestCreateStory() {
 	json := []models.Story{
 		{
-			Title:    "Jane Eyre",
-			Content:  "Classic",
-			AuthorID: 2,
+			Title:           "Jane Eyre",
+			Content:         "Classic",
+			AuthorFirstName: "Charlotte",
+			AuthorLastName:  "Bronte",
+			AuthorCountry:   "UK",
 		},
 	}
 
@@ -179,11 +196,13 @@ func (suite *endpointTestSuite) TestCreateStory() {
 func (suite *endpointTestSuite) TestGetStoryByID() {
 	json := []models.Story{
 		{
-			Title:       "Swan Lake for Beginners",
-			Content:     "Short Story",
-			Summary:     "Summary1",
-			CurrentCity: "Toronto",
-			AuthorID:    1,
+			Title:           "Half of a Yellow Sun",
+			Content:         "Fiction",
+			Summary:         "Summary1",
+			CurrentCity:     "Toronto",
+			AuthorFirstName: "Chimamanda",
+			AuthorLastName:  "Ngozi Adieche",
+			AuthorCountry:   "Nigeria",
 		},
 	}
 
@@ -195,22 +214,25 @@ func (suite *endpointTestSuite) TestGetStoryByID() {
 	mock := `{
 				"payload": [
 				{
-					"author_id": 1,
-					"content": "Short Story",
-					"title": "Swan Lake for Beginners",
+					"author_country": "Nigeria",
+					"author_first_name": "Chimamanda",
+					"author_last_name": "Ngozi Adieche",
+					"current_city": "Toronto",
+					"content": "Fiction",
 					"summary": "Summary1",
-					"current_city": "Toronto"
+					"title": "Half of a Yellow Sun"
 				}],
 				"status": "OK"
 			}`
 	//Verify they are the same
 	response.Schema(mock)
-	response.Object().Value("payload").Object().Value("ID").Equal(1)
-	response.Object().Value("payload").Object().Value("content").Equal("Short Story")
-	response.Object().Value("payload").Object().Value("title").Equal("Swan Lake for Beginners")
+	response.Object().Value("payload").Object().Value("author_first_name").Equal("Chimamanda")
+	response.Object().Value("payload").Object().Value("author_last_name").Equal("Ngozi Adieche")
+	response.Object().Value("payload").Object().Value("author_country").Equal("Nigeria")
+	response.Object().Value("payload").Object().Value("content").Equal("Fiction")
+	response.Object().Value("payload").Object().Value("title").Equal("Half of a Yellow Sun")
 	response.Object().Value("payload").Object().Value("summary").Equal("Summary1")
 	response.Object().Value("payload").Object().Value("current_city").Equal("Toronto")
-
 }
 
 func (suite *endpointTestSuite) TearDownSuite() {


### PR DESCRIPTION
The set `(FirstName, LastName, OriginCountry)` identifies each author uniquely now. If any one of them is different, a new author is created. If all three are the same, a `duplicate primary key` error is thrown.

The foreign keys in `stories` are updated to these three fields. `AuthorID` is no longer column or foreign key in the `stories` table.

aside: I'm starting to think we should have unit tests for db.