### PR TITLE
Get stories by countries endpoint

### DIFF
--- a/restapi/api.go
+++ b/restapi/api.go
@@ -33,6 +33,7 @@ func Router(db *gorm.DB, locationFinder location.LocationFinder) (http.Handler, 
 	r.Group(func(r chi.Router) {
 		rest.GetHandler(r, "/health", api.health)
 		rest.GetHandler(r, "/stories", api.ReturnAllStories)
+		rest.GetHandler(r, "/stories/{countries}", api.ReturnStoriesByCountries)
 		rest.GetHandler(r, "/story/{storyID}", api.ReturnStoryByID)
 		rest.GetHandler(r, "/authors/origin_countries", api.ReturnAllCountries)
 		rest.PostHandler(r, "/login", api.Login)

--- a/restapi/endpoints_test.go
+++ b/restapi/endpoints_test.go
@@ -80,6 +80,7 @@ func (suite *endpointTestSuite) TestReturnStoriesByCountries() {
 			AuthorFirstName: "Chimamanda",
 			AuthorLastName:  "Ngozi Adieche",
 			AuthorCountry:   "Nigeria",
+			CurrentCity:     "Toronto",
 		},
 		{
 			Title:           "Jane Eyre",
@@ -87,6 +88,7 @@ func (suite *endpointTestSuite) TestReturnStoriesByCountries() {
 			AuthorFirstName: "Charlotte",
 			AuthorLastName:  "Bronte",
 			AuthorCountry:   "UK",
+			CurrentCity:     "Montreal",
 		},
 	}
 
@@ -103,12 +105,14 @@ func (suite *endpointTestSuite) TestReturnStoriesByCountries() {
 	response.Object().Value("payload").Array().Element(0).Object().Value("author_country").Equal("Nigeria")
 	response.Object().Value("payload").Array().Element(0).Object().Value("content").Equal("Fiction")
 	response.Object().Value("payload").Array().Element(0).Object().Value("title").Equal("Half of a Yellow Sun")
+	response.Object().Value("payload").Array().Element(0).Object().Value("current_city").Equal("Toronto")
 
 	response.Object().Value("payload").Array().Element(1).Object().Value("author_first_name").Equal("Charlotte")
 	response.Object().Value("payload").Array().Element(1).Object().Value("author_last_name").Equal("Bronte")
 	response.Object().Value("payload").Array().Element(1).Object().Value("author_country").Equal("UK")
 	response.Object().Value("payload").Array().Element(1).Object().Value("content").Equal("Classic")
 	response.Object().Value("payload").Array().Element(1).Object().Value("title").Equal("Jane Eyre")
+	response.Object().Value("payload").Array().Element(1).Object().Value("current_city").Equal("Montreal")
 }
 
 func (suite *endpointTestSuite) TestGetAllStories() {

--- a/restapi/endpoints_test.go
+++ b/restapi/endpoints_test.go
@@ -72,6 +72,45 @@ func (suite *endpointTestSuite) TestHealthCheck() {
 		Status(http.StatusOK).JSON().Object().Value("message").String().Equal("Hello World")
 }
 
+func (suite *endpointTestSuite) TestReturnStoriesByCountries() {
+	json := []models.Story{
+		{
+			Title:           "Half of a Yellow Sun",
+			Content:         "Fiction",
+			AuthorFirstName: "Chimamanda",
+			AuthorLastName:  "Ngozi Adieche",
+			AuthorCountry:   "Nigeria",
+		},
+		{
+			Title:           "Jane Eyre",
+			Content:         "Classic",
+			AuthorFirstName: "Charlotte",
+			AuthorLastName:  "Bronte",
+			AuthorCountry:   "UK",
+		},
+	}
+
+	suite.db.Create(&json)
+
+	var response = suite.endpoint.GET("/stories/countries=France,Nigeria,UK").
+		Expect().
+		Status(http.StatusOK).JSON()
+
+	response.Object().Value("payload").Array().Length().Equal(2)
+
+	response.Object().Value("payload").Array().Element(0).Object().Value("author_first_name").Equal("Chimamanda")
+	response.Object().Value("payload").Array().Element(0).Object().Value("author_last_name").Equal("Ngozi Adieche")
+	response.Object().Value("payload").Array().Element(0).Object().Value("author_country").Equal("Nigeria")
+	response.Object().Value("payload").Array().Element(0).Object().Value("content").Equal("Fiction")
+	response.Object().Value("payload").Array().Element(0).Object().Value("title").Equal("Half of a Yellow Sun")
+
+	response.Object().Value("payload").Array().Element(1).Object().Value("author_first_name").Equal("Charlotte")
+	response.Object().Value("payload").Array().Element(1).Object().Value("author_last_name").Equal("Bronte")
+	response.Object().Value("payload").Array().Element(1).Object().Value("author_country").Equal("UK")
+	response.Object().Value("payload").Array().Element(1).Object().Value("content").Equal("Classic")
+	response.Object().Value("payload").Array().Element(1).Object().Value("title").Equal("Jane Eyre")
+}
+
 func (suite *endpointTestSuite) TestGetAllStories() {
 	json_story1 := []models.Story{
 		{

--- a/restapi/stories.go
+++ b/restapi/stories.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/go-chi/chi"
 	"github.com/go-chi/render"
@@ -62,4 +63,18 @@ func (api api) CreateStories(w http.ResponseWriter, r *http.Request) render.Rend
 	}
 
 	return rest.MsgStatusOK("Stories added successfully")
+}
+
+func (api api) ReturnStoriesByCountries(w http.ResponseWriter, r *http.Request) render.Renderer {
+	countriesString := chi.URLParam(r, "countries")
+	countries := strings.Split(countriesString, ",")
+
+	var stories []models.Story
+
+	err := api.database.Where("author_country IN ?", countries).Find(&stories).Error
+	if err != nil {
+		return rest.ErrInternal(api.logger, err)
+	}
+
+	return rest.JSONStatusOK(stories)
 }


### PR DESCRIPTION
Closes https://github.com/uwblueprint/shoe-project/issues/88

Query passed into url as `/api/stories/Country1,Country2`
searches for all stories with `origin_country IN [Country1, Country2]`


_NB:_ right now, capitalization matters (`country1 != Country1`). we should probably make everything in db lowercase? 