### PR TITLE
Resizing map and moving location of zoom control

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { SWRConfig } from "swr";
-import { BrowserRouter as Router, Switch, Route, Link } from "react-router-dom";
+import { BrowserRouter as Router, Switch, Route} from "react-router-dom";
 
 import { Home, ShoeMap } from "./pages";
 
@@ -20,17 +20,6 @@ function App(): JSX.Element {
       }}
     >
       <Router>
-        <nav>
-          <ul>
-            <li>
-              <Link to="/">Home</Link>
-            </li>
-            <li>
-              <Link to="/map">ShoeMap</Link>
-            </li>
-          </ul>
-        </nav>
-
         <Switch>
           <Route exact path="/">
             <Home />

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { SWRConfig } from "swr";
-import { BrowserRouter as Router, Switch, Route} from "react-router-dom";
+import { BrowserRouter as Router, Switch, Route } from "react-router-dom";
 
 import { Home, ShoeMap } from "./pages";
 

--- a/ui/src/pages/ShoeMap.tsx
+++ b/ui/src/pages/ShoeMap.tsx
@@ -1,14 +1,14 @@
 import * as React from "react";
 import styled from "styled-components";
-import { Map, TileLayer } from "react-leaflet";
+import { Map, TileLayer, ZoomControl } from "react-leaflet";
+import L from "leaflet";
 import "leaflet/dist/leaflet.css";
 
 import { Pin, PinState } from "../components/Pin";
-import { TitleText } from "../styles/typography";
 
 const StyledMap = styled(Map)`
-  height: 70vh;
-  width: 90vw;
+  height: 100vh;
+  width: 100vw;
 `;
 
 const MapContainer = styled.div`
@@ -25,8 +25,7 @@ export const ShoeMap: React.FC = () => {
 
   return (
     <MapContainer>
-      <TitleText>Shoe Map</TitleText>
-      <StyledMap center={currentLocation} zoom={zoom}>
+      <StyledMap center={currentLocation} zoom={zoom} zoomControl={false}>
         <TileLayer
           url={`https://api.mapbox.com/styles/v1/mapbox/streets-v9/tiles/{z}/{x}/{y}?access_token=${process.env.REACT_APP_MAPBOX_ACCESS_TOKEN}`}
         />
@@ -34,6 +33,7 @@ export const ShoeMap: React.FC = () => {
           position={[currentLocation.lat, currentLocation.lng]}
           state={PinState.Resting}
         />
+        <ZoomControl position='topright'/>
       </StyledMap>
     </MapContainer>
   );

--- a/ui/src/pages/ShoeMap.tsx
+++ b/ui/src/pages/ShoeMap.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
 import styled from "styled-components";
 import { Map, TileLayer, ZoomControl } from "react-leaflet";
-import L from "leaflet";
 import "leaflet/dist/leaflet.css";
 
 import { Pin, PinState } from "../components/Pin";
@@ -33,7 +32,7 @@ export const ShoeMap: React.FC = () => {
           position={[currentLocation.lat, currentLocation.lng]}
           state={PinState.Resting}
         />
-        <ZoomControl position='topright'/>
+        <ZoomControl position="topright" />
       </StyledMap>
     </MapContainer>
   );


### PR DESCRIPTION
**Summary**
- Resized map to be full screen and removed title
- Moved zoom control buttons to the top right corner instead of top left so they don't interfere with the filter

![image](https://user-images.githubusercontent.com/18248358/98876139-9d970780-244b-11eb-9f50-cce0a55fc23e.png)
