### PR TITLE
Add custom zoom control and help button

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -30,6 +30,7 @@
     "react-dom": ">= 16.8.0",
     "react-is": "^16.13.1",
     "react-leaflet": "^2.7.0",
+    "react-leaflet-control": "^2.1.2",
     "react-leaflet-markercluster": "^2.0.0",
     "react-router-dom": "^5.2.0",
     "styled-components": "^5.2.0",

--- a/ui/src/pages/ShoeMap.tsx
+++ b/ui/src/pages/ShoeMap.tsx
@@ -1,15 +1,61 @@
 import * as React from "react";
 import styled from "styled-components";
-import { Map, TileLayer, ZoomControl } from "react-leaflet";
+import { AttributionControl, Map, TileLayer, ZoomControl } from "react-leaflet";
+import Control from "react-leaflet-control";
 import "leaflet/dist/leaflet.css";
 import { PinCluster } from "../components/PinCluster";
 import { StoryDrawer, StoryDrawerState } from "../components/StoryDrawer";
 import { useState } from "react";
-import ShoeMapLogo from "../assets/shoe-project-logo.svg";
+import { colors } from "../styles";
 
 const StyledMap = styled(Map)`
   height: 100vh;
   width: 100vw;
+
+  .leaflet-control {
+    border: none;
+    box-shadow: 0px 0px 25px rgba(0, 0, 0, 0.1);
+    margin: 0px 24px 24px 0px;
+  }
+
+  .leaflet-bar a {
+    width: 48px;
+    height: 48px;
+    background-color: ${colors.white};
+    font-size: 26px;
+    line-height: 45px;
+    box-shadow: 0px 0px 25px rgba(0, 0, 0, 0.1);
+
+    :first-child {
+      border-radius: 10px 10px 0px 0px;
+    }
+    :last-child {
+      border-radius: 0px 0px 10px 10px;
+    }
+  }
+`;
+
+const StyledHelpIcon = styled.button`
+  height: 48px;
+  width: 48px;
+  font-size: 26px;
+  font-weight: 500;
+  border: none;
+  background-color: ${colors.white};
+  border-radius: 10px;
+  box-shadow: 0px 0px 25px 5px rgba(0, 0, 0, 0.1);
+
+  &:hover {
+    cursor: pointer;
+    color: ${colors.primaryDark1};
+  }
+
+  &:focus {
+    outline: 0;
+    font-weight: 600;
+    color: ${colors.primaryDark1};
+    border: 2px solid ${colors.primaryDark1};
+  }
 `;
 
 const MapContainer = styled.div`
@@ -52,6 +98,7 @@ export const ShoeMap: React.FC = () => {
           minZoom={minZoom}
           maxZoom={maxZoom}
           zoomControl={false}
+          attributionControl={false}
         >
           <TileLayer
             url={`https://api.mapbox.com/styles/v1/hanlinc27/ckhjy5wat2dvz1aplv4tkaghb/tiles/{z}/{x}/{y}?access_token=${process.env.REACT_APP_MAPBOX_ACCESS_TOKEN}`}
@@ -60,7 +107,11 @@ export const ShoeMap: React.FC = () => {
             clusterPositions={markerList}
             openDrawer={() => setIsDrawerOpen(StoryDrawerState.Open)}
           />
-          <ZoomControl position="topright" />
+          <ZoomControl position="bottomright" />
+          <AttributionControl position="bottomleft" />
+          <Control position="bottomright">
+            <StyledHelpIcon>?</StyledHelpIcon>
+          </Control>
         </StyledMap>
       </MapContainer>
       <StoryDrawer

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -6870,6 +6870,7 @@ range-parser@~1.2.1:
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
+    prop-types "^15.6.2"
     scheduler "^0.20.1"
 
 react-is@^16.12.0, react-is@^16.13.1, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.0, react-is@^16.8.1:
@@ -6881,6 +6882,11 @@ react-is@^17.0.1:
   version "17.0.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.1.tgz#5b3531bd76a645a4c9fb6e693ed36419e3301339"
   integrity sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==
+
+react-leaflet-control@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/react-leaflet-control/-/react-leaflet-control-2.1.2.tgz#c716c5c1797375e4fd941c9e2e0c148bc34edbb0"
+  integrity sha512-xdheoLuLEeDGZ6/FKsnKjMYxC9BlyxsK5L5S27Dd6Z+FYP4jIa1Ekhu7UDgTV7GGSw+Yjjf8uofoheylxggB6w==
 
 react-leaflet-markercluster@^2.0.0:
   version "2.0.0"
@@ -6947,6 +6953,7 @@ react-transition-group@^4.4.0:
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
+    prop-types "^15.6.2"
 
 read-pkg-up@^7.0.1:
   version "7.0.1"


### PR DESCRIPTION
**Summary**
- Add help button according to Figma designs
- Style zoom control buttons
- Move attribution

Resting
![image](https://user-images.githubusercontent.com/18248358/100290900-63992b80-2f4a-11eb-8626-922323f1e7f7.png)

Hover
![image](https://user-images.githubusercontent.com/18248358/100290913-6b58d000-2f4a-11eb-9617-c7078e04a16a.png)

Selected
![image](https://user-images.githubusercontent.com/18248358/100290921-71e74780-2f4a-11eb-9b7b-6479ae60c1d7.png)




