### PR TITLE
Update Base Map Style

### DIFF
--- a/ui/src/pages/ShoeMap.tsx
+++ b/ui/src/pages/ShoeMap.tsx
@@ -40,7 +40,7 @@ export const ShoeMap: React.FC = () => {
     <MapContainer>
       <StyledMap center={currentLocation} zoom={zoom} zoomControl={false}>
         <TileLayer
-          url={`https://api.mapbox.com/styles/v1/mapbox/streets-v9/tiles/{z}/{x}/{y}?access_token=${process.env.REACT_APP_MAPBOX_ACCESS_TOKEN}`}
+          url={`https://api.mapbox.com/styles/v1/hanlinc27/ckhjy5wat2dvz1aplv4tkaghb/tiles/{z}/{x}/{y}?access_token=${process.env.REACT_APP_MAPBOX_ACCESS_TOKEN}`}
         />
         <PinCluster clusterPositions={markerList} />ß
         <ZoomControl position="topright" />


### PR DESCRIPTION
Super tiny change to update the styling on base map according to Figma.
![image](https://user-images.githubusercontent.com/19617248/99209216-a57ae280-2790-11eb-8f5c-ad42f95ca2ae.png)
The style can be viewed here: https://api.mapbox.com/styles/v1/hanlinc27/ckhjy5wat2dvz1aplv4tkaghb.html?fresh=true&title=view&access_token=pk.eyJ1IjoiaGFubGluYzI3IiwiYSI6ImNraGp4ZTgxNTAzODYycnFpNmRmNWpqcm0ifQ.t7GsrEh0uyiCIQM-lNz8lQ

Closes #115 