### PR TITLE
ref: Clean up styling to remove console error

### DIFF
--- a/ui/src/components/StoryDrawer.tsx
+++ b/ui/src/components/StoryDrawer.tsx
@@ -96,6 +96,7 @@ export function StoryDrawer({ story, onClose }: StoryDrawerProps): JSX.Element {
             alignItems="flex-end"
             alignContent="flex-end"
             justify="flex-end"
+            container
           >
             <DrawerRightText>{current_city}, Canada</DrawerRightText>
             <DrawerRightText>{date}</DrawerRightText>

--- a/ui/src/components/WelcomeTutorial.tsx
+++ b/ui/src/components/WelcomeTutorial.tsx
@@ -55,17 +55,16 @@ const StyledFilterOverlay = styled.img`
 `;
 
 const StyledIconButton = styled(IconButton)`
-    position: absolute;
-    margin: 0px;
-    padding: 0px;
-    left: 372px;
-    top: 29px;
-    width: 14px;
-    height: 14px;   
+  position: absolute;
+  margin: 0px;
+  padding: 0px;
+  left: 372px;
+  top: 29px;
+  width: 14px;
+  height: 14px;
 
   && {
     box-shadow: none;
-  }
   }
 `;
 
@@ -168,23 +167,24 @@ const StyledTag = styled(Button)`
     line-height: 24px;
     margin: 0px 10px;
   }
+
   && {
     box-shadow: none;
-    background-color: ${colors.neutralLight};    
+    background-color: ${colors.neutralLight};
+  }
 `;
 
 const StyledWelcomeIconButton = styled(IconButton)`
-    position: absolute;
-    margin: 0px;
-    padding: 0px;
-    left: 455px;
-    top: 29px;
-    width: 14px;
-    height: 14px;
+  position: absolute;
+  margin: 0px;
+  padding: 0px;
+  left: 455px;
+  top: 29px;
+  width: 14px;
+  height: 14px;
 
   && {
     box-shadow: none;
-  }
   }
 `;
 
@@ -206,6 +206,8 @@ const StyledWelcomeButton = styled(Button)`
   position: absolute;
   left: 134px;
   bottom: 24px;
+  color: ${colors.primaryLight2};
+
   .MuiButton-label {
     color: ${colors.primaryDark2};
     font-size: 16px;
@@ -215,6 +217,7 @@ const StyledWelcomeButton = styled(Button)`
     line-height: 150%;
     margin: 0px 10px;
   }
+
   && {
     box-shadow: none;
     background-color: ${colors.primaryLight4};
@@ -238,17 +241,16 @@ const StyledWelcomeLogo = styled.img`
 `;
 
 const StyledNavigateIconButton = styled(IconButton)`
-    position: absolute;
-    margin: 0px;
-    padding: 0px;
-    left: 372px;
-    top: 29px;
-    width: 14px;
-    height: 14px;
+  position: absolute;
+  margin: 0px;
+  padding: 0px;
+  left: 372px;
+  top: 29px;
+  width: 14px;
+  height: 14px;
 
   && {
     box-shadow: none;
-  }
   }
 `;
 
@@ -261,6 +263,7 @@ const StyledNavigateWelcome = styled(Dialog)`
     border-radius: 10px;
     margin: 0px;
   }
+
   .MuiBackdrop-root {
     background-color: transparent;
   }
@@ -306,7 +309,8 @@ const StyledNavigateTag = styled(Button)`
   }
   && {
     box-shadow: none;
-    background-color: ${colors.neutralLight};    
+    background-color: ${colors.neutralLight};
+  }
 `;
 
 const StyledContainer = styled.div`
@@ -353,7 +357,6 @@ export function WelcomeTutorial({
         <StyledWelcomeButton
           text-align="center"
           variant="text"
-          color={colors.primaryLight2}
           disableElevation={true}
           onClick={() => setState(TutorialState.Second)}
         >

--- a/ui/src/pages/ShoeMap.tsx
+++ b/ui/src/pages/ShoeMap.tsx
@@ -87,7 +87,7 @@ export const ShoeMap: React.FC = () => {
     setFilteredCountries(options);
   }
   const stories =
-    filteredCountries.length === 0
+    !data || filteredCountries.length === 0
       ? data
       : data.filter((story) =>
           filteredCountries.includes(story.author_country)


### PR DESCRIPTION
There were some console errors occuring, this PR just cleans them up.

1) Added a container prop to the `Grid` component used by `StoryDrawer` (container is required if you want to use `alignItems`/`alignContent`)

2) `color` prop was erroring for button component in `WelcomeTutorial`, so just moved that into the css (also formatted the css for `WelcomeTutorial` a little bit.