### PR TITLE
randomize location, fix date styling, fix drawer content styling

### DIFF
--- a/ui/src/components/Pin.tsx
+++ b/ui/src/components/Pin.tsx
@@ -28,6 +28,12 @@ const StyledPopup = styled(Popup)`
   }
 `;
 
+function randomCoords(coordinate: number): number{
+  var num = Math.floor(Math.random()*99) + 1;
+  num *= Math.round(Math.random()) ? 1 : -1; 
+  return (coordinate+0.1*num);
+}
+
 export enum PinState {
   Resting,
   Selected,
@@ -59,7 +65,7 @@ export function Pin({
   });
 
   return (
-    <Marker position={[story.latitude, story.longitude]} icon={icon}>
+    <Marker position={[randomCoords(story.latitude), randomCoords(story.longitude)]} icon={icon}>
       <StyledPopup>
         <PinPreview
           shoeImage={story.image_url}

--- a/ui/src/components/Pin.tsx
+++ b/ui/src/components/Pin.tsx
@@ -28,10 +28,10 @@ const StyledPopup = styled(Popup)`
   }
 `;
 
-function randomCoords(coordinate: number): number{
-  var num = Math.floor(Math.random()*99) + 1;
-  num *= Math.round(Math.random()) ? 1 : -1; 
-  return (coordinate+0.01*num);
+function randomCoords(coordinate: number): number {
+  let num = Math.floor(Math.random() * 99) + 1;
+  num *= Math.round(Math.random()) ? 1 : -1;
+  return coordinate + 0.01 * num;
 }
 
 export enum PinState {
@@ -65,7 +65,10 @@ export function Pin({
   });
 
   return (
-    <Marker position={[randomCoords(story.latitude), randomCoords(story.longitude)]} icon={icon}>
+    <Marker
+      position={[randomCoords(story.latitude), randomCoords(story.longitude)]}
+      icon={icon}
+    >
       <StyledPopup>
         <PinPreview
           shoeImage={story.image_url}

--- a/ui/src/components/Pin.tsx
+++ b/ui/src/components/Pin.tsx
@@ -31,7 +31,7 @@ const StyledPopup = styled(Popup)`
 function randomCoords(coordinate: number): number{
   var num = Math.floor(Math.random()*99) + 1;
   num *= Math.round(Math.random()) ? 1 : -1; 
-  return (coordinate+0.1*num);
+  return (coordinate+0.01*num);
 }
 
 export enum PinState {

--- a/ui/src/components/PinCluster.tsx
+++ b/ui/src/components/PinCluster.tsx
@@ -31,14 +31,15 @@ export const PinCluster = React.memo(function PinCluster({
       showCoverageOnHover={false}
       spiderLegPolylineOptions={{ opacity: 0 }}
       iconCreateFunction={createClusterCustomIcon}
-    >
+      zoomToBoundsOnClick={true}
+>
       {stories.map((story) => {
         return (
           <Pin
             id={story.ID.toString()}
             key={story.ID}
             story={story}
-            state={PinState.Unfocused}
+            state={PinState.Resting}
             onPopupClick={openDrawer(story)}
           />
         );

--- a/ui/src/components/PinCluster.tsx
+++ b/ui/src/components/PinCluster.tsx
@@ -32,7 +32,7 @@ export const PinCluster = React.memo(function PinCluster({
       spiderLegPolylineOptions={{ opacity: 0 }}
       iconCreateFunction={createClusterCustomIcon}
       zoomToBoundsOnClick={true}
->
+    >
       {stories.map((story) => {
         return (
           <Pin

--- a/ui/src/components/PinPreview.tsx
+++ b/ui/src/components/PinPreview.tsx
@@ -72,7 +72,7 @@ export function PinPreview({
           Read Full Story
         </StyledButton>
         <CardDetailText>
-          {author} • {date}
+          {author} • {date.substring(0,4)}
         </CardDetailText>
       </StyledCardContent>
     </>

--- a/ui/src/components/PinPreview.tsx
+++ b/ui/src/components/PinPreview.tsx
@@ -72,7 +72,7 @@ export function PinPreview({
           Read Full Story
         </StyledButton>
         <CardDetailText>
-          {author} • {date.substring(0, 4)}
+          {author} • {date}
         </CardDetailText>
       </StyledCardContent>
     </>

--- a/ui/src/components/PinPreview.tsx
+++ b/ui/src/components/PinPreview.tsx
@@ -72,7 +72,7 @@ export function PinPreview({
           Read Full Story
         </StyledButton>
         <CardDetailText>
-          {author} • {date.substring(0,4)}
+          {author} • {date.substring(0, 4)}
         </CardDetailText>
       </StyledCardContent>
     </>

--- a/ui/src/components/WelcomeTutorial.tsx
+++ b/ui/src/components/WelcomeTutorial.tsx
@@ -5,11 +5,6 @@ import CloseIcon from "@material-ui/icons/Close";
 import * as React from "react";
 import styled from "styled-components";
 
-<<<<<<< HEAD
-import OverlayCircle from "../assets/images/small-clear-circle.svg";
-=======
-import BigOverlayCircle from "../assets/images/clear-circle.svg";
->>>>>>> 5966a67... takeout overlay on tutorial for now
 import ShoeLogo from "../assets/images/welcome-shoe-logo.svg";
 import DialogTip from "../assets/images/white-arrow.png";
 import { colors } from "../styles/colors";

--- a/ui/src/components/WelcomeTutorial.tsx
+++ b/ui/src/components/WelcomeTutorial.tsx
@@ -5,7 +5,11 @@ import CloseIcon from "@material-ui/icons/Close";
 import * as React from "react";
 import styled from "styled-components";
 
+<<<<<<< HEAD
 import OverlayCircle from "../assets/images/small-clear-circle.svg";
+=======
+import BigOverlayCircle from "../assets/images/clear-circle.svg";
+>>>>>>> 5966a67... takeout overlay on tutorial for now
 import ShoeLogo from "../assets/images/welcome-shoe-logo.svg";
 import DialogTip from "../assets/images/white-arrow.png";
 import { colors } from "../styles/colors";
@@ -31,16 +35,6 @@ const StyledFilterArrowTip = styled.img`
   height: 26px;
   left: -5%;
   top: 15%;
-  background: none;
-`;
-
-const StyledOverlay = styled.img`
-  position: absolute;
-  width: 84px;
-  height: 84px;
-  right: -68%;
-  top: 23%;
-  opacity: 15%
   background: none;
 `;
 
@@ -386,7 +380,6 @@ export function WelcomeTutorial({
 
       <StyledWelcome open={state === TutorialState.Third} onClose={handleClose}>
         <StyledArrowTip src={DialogTip}></StyledArrowTip>
-        <StyledOverlay src={OverlayCircle}></StyledOverlay>
         <StyledIconButton onClick={handleClose}>
           <StyledCloseIcon color="primary" fontSize="small" />
         </StyledIconButton>

--- a/ui/src/styles/typography.ts
+++ b/ui/src/styles/typography.ts
@@ -193,7 +193,7 @@ export const StoryDrawerRightText = styled.div`
 
 export const StoryDrawerContentText = styled.span`
   font-size: ${fontSize.subtitle};
-  white-space: pre-line; 
+  white-space: pre-line;
   font-style: normal;
   font-weight: 400;
   line-height: 32px;

--- a/ui/src/styles/typography.ts
+++ b/ui/src/styles/typography.ts
@@ -110,6 +110,7 @@ export const NavigateDescriptionText = styled.p`
 
 export const CardDetailText = styled.p`
   font-size: ${fontSize.caption};
+  font-family: Poppins;
   font-weight: 300;
   line-height: 21px;
   text-align: left;
@@ -192,6 +193,7 @@ export const StoryDrawerRightText = styled.div`
 
 export const StoryDrawerContentText = styled.span`
   font-size: ${fontSize.subtitle};
+  white-space: pre-line; 
   font-style: normal;
   font-weight: 400;
   line-height: 32px;


### PR DESCRIPTION
@dhillondeep should fix the spiral issue?
### Description
Thoughts on randomizing the coordinates slightly on the client side so that the clusters can be zoomed in?
Closes #151 
![cluster](https://user-images.githubusercontent.com/19617248/102421268-0c7af980-3fd2-11eb-9b23-b41a295effcc.gif)

Preview date styling: 
![image](https://user-images.githubusercontent.com/19617248/102421514-932fd680-3fd2-11eb-97b7-ae828cc28345.png)


Add in the new lines on story drawer content: 
![image](https://user-images.githubusercontent.com/19617248/102421532-9e830200-3fd2-11eb-8b6e-325a02d07e0e.png)
