### PR TITLE
fix: Don't justify PinPreview text

### DIFF
--- a/ui/src/styles/typography.ts
+++ b/ui/src/styles/typography.ts
@@ -54,7 +54,6 @@ export const CardDescriptionText = styled.p`
   font-family: Poppins;
   font-weight: normal;
   line-height: 24px;
-  text-align: justify;
   color: ${colors.black};
   opacity: 0.7;
   margin: 0;


### PR DESCRIPTION
## Before

![image](https://user-images.githubusercontent.com/18689448/105119308-0c24c100-5a9e-11eb-8218-f954793fbd76.png)

## After

![image](https://user-images.githubusercontent.com/18689448/105119282-fe6f3b80-5a9d-11eb-81a3-c645c6b9352e.png)
