### PR TITLE
fix: pin preivew doesn't overlap with filter

### DIFF
--- a/ui/src/components/Pin.tsx
+++ b/ui/src/components/Pin.tsx
@@ -50,7 +50,7 @@ export function Pin({
     iconUrl: state === PinState.Unfocused ? unfocused : resting,
     iconRetinaUrl: state === PinState.Unfocused ? unfocused : resting,
     iconAnchor: state === PinState.Selected ? [29, 70] : [25, 61],
-    popupAnchor: [-234, 200],
+    popupAnchor: [234, -100],
     shadowUrl: null,
     shadowSize: null,
     shadowAnchor: null,
@@ -58,9 +58,15 @@ export function Pin({
       state === PinState.Selected ? new L.Point(48, 57) : new L.Point(39, 48),
   });
 
+  const leftPaddingPoint = L.point(500, 75);
+  const rightPaddingPoint = L.point(100, 400);
+
   return (
     <Marker position={[story.latitude, story.longitude]} icon={icon}>
-      <StyledPopup>
+      <StyledPopup
+        autoPanPaddingTopLeft={leftPaddingPoint}
+        autoPanPaddingBottomRight={rightPaddingPoint}
+      >
         <PinPreview
           shoeImage={story.image_url}
           title={story.title}

--- a/ui/src/styles/typography.ts
+++ b/ui/src/styles/typography.ts
@@ -54,7 +54,6 @@ export const CardDescriptionText = styled.p`
   font-family: Poppins;
   font-weight: normal;
   line-height: 24px;
-  text-align: justify;
   color: ${colors.black};
   opacity: 0.7;
   margin: 0;


### PR DESCRIPTION
## Resolves #179 

## Description: 
Snap pin preview to the centre of the screen if it is overlapping with the filter. Also added padding on the right to make sure longer story previews fit on the screen. 

## Demo: 
### Before:
![image](https://user-images.githubusercontent.com/50289930/105122914-1c8c6a00-5aa5-11eb-8276-be5a8d6f7466.png)
### After: 
![image](https://user-images.githubusercontent.com/50289930/105123007-4ba2db80-5aa5-11eb-8e55-16c6d9ca65ee.png)
