### PR TITLE
feat: Add Video into story drawer

### DIFF
--- a/ui/src/components/StoryDrawer.tsx
+++ b/ui/src/components/StoryDrawer.tsx
@@ -122,7 +122,7 @@ export function StoryDrawer({ story, onClose }: StoryDrawerProps): JSX.Element {
           </Grid>
           <Grid item xs={12}>
             <StyledVideo
-              src="https://www.youtube.com/embed/O0xn7fNpwiU"
+              src={video_url}
               frameborder="0"
               allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
               allowfullscreen

--- a/ui/src/components/StoryDrawer.tsx
+++ b/ui/src/components/StoryDrawer.tsx
@@ -65,6 +65,11 @@ const StyledDrawerContainer = styled.div`
   margin-bottom: 21px;
 `;
 
+const StyledVideo = styled.iframe`
+  height: 40vw;
+  width: 100%;
+`;
+
 interface StoryDrawerProps {
   story?: Story;
   onClose: () => void;
@@ -83,6 +88,7 @@ export function StoryDrawer({ story, onClose }: StoryDrawerProps): JSX.Element {
     current_city,
     content,
     image_url,
+    video_url,
     year,
   } = story;
 
@@ -113,6 +119,14 @@ export function StoryDrawer({ story, onClose }: StoryDrawerProps): JSX.Element {
           </Grid>
           <Grid item xs={12}>
             <StoryDrawerContentText>{content}</StoryDrawerContentText>
+          </Grid>
+          <Grid item xs={12}>
+            <StyledVideo
+              src="https://www.youtube.com/embed/O0xn7fNpwiU"
+              frameborder="0"
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+              allowfullscreen
+            ></StyledVideo>
           </Grid>
         </Grid>
       </StyledRoot>

--- a/ui/src/components/StoryDrawer.tsx
+++ b/ui/src/components/StoryDrawer.tsx
@@ -120,14 +120,16 @@ export function StoryDrawer({ story, onClose }: StoryDrawerProps): JSX.Element {
           <Grid item xs={12}>
             <StoryDrawerContentText>{content}</StoryDrawerContentText>
           </Grid>
-          <Grid item xs={12}>
-            <StyledVideo
-              src={video_url}
-              frameborder="0"
-              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-              allowfullscreen
-            ></StyledVideo>
-          </Grid>
+          {video_url && (
+            <Grid item xs={12}>
+              <StyledVideo
+                src={video_url}
+                frameborder="0"
+                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                allowfullscreen
+              ></StyledVideo>
+            </Grid>
+          )}
         </Grid>
       </StyledRoot>
     </StyledDrawer>


### PR DESCRIPTION
Added the link into the story model on the frontend, need to wait until DB is populated to load the actual videos in though, using a filler for now. 
### Example

![9f04c97e-d6f8-4cd9-830c-20ba54081ec7 (1)](https://user-images.githubusercontent.com/19617248/106692685-ef5eb200-65a2-11eb-8be3-ea6581d1c78b.gif)

Closes #201 
Closes #199 