### PR TITLE
google oauth setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ You can check locally to make sure none of these issues show up by:
 make backend-check
 ```
 
-## Authentication
+<!-- ## Authentication
 All the `create` endpoints are protected, which means you have to login before you can make POST requests to these endpoints.
 
 1. Make sure that you have the latest `.env` file (pinned on Slack channel) in the *root* of your `shoe-project` directory.
@@ -145,7 +145,7 @@ $ TOKEN=<JWT-Token>
 $ curl -H 'Accept: application/json' -H "Authorization: Bearer ${TOKEN}" http://localhost:8900/api/<protected-endpoint>
 ```
 
-Note that the key `Authorization: Bearer` is fixed, so don't change this.
+Note that the key `Authorization: Bearer` is fixed, so don't change this. -->
 
 ## Running Script
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ You can check locally to make sure none of these issues show up by:
 ```bash
 make backend-check
 ```
-
+<!-- TOOD: add auth docs -->
 <!-- ## Authentication
 All the `create` endpoints are protected, which means you have to login before you can make POST requests to these endpoints.
 

--- a/cmd/seed.go
+++ b/cmd/seed.go
@@ -38,10 +38,6 @@ var (
 				logger.Fatalw("Database table creation failed", "Err", err)
 			}
 
-			if err := migrations.CreateSuperUser(db); err != nil {
-				logger.Fatalw("Super user creation failed", "Err", err)
-			}
-
 			locationFinder, err := location.NewMapboxFinder(config.GetMapBoxToken(), "CA")
 			if err != nil {
 				logger.Fatalw("Failed to initialize Mapbox location finder service")

--- a/config/getter.go
+++ b/config/getter.go
@@ -183,6 +183,14 @@ func GetTokenIssuer() string {
 	return viper.GetString("auth.jwt_issuer")
 }
 
+func GetGoogleClientId() string {
+	return viper.GetString("google.client_id")
+}
+
+func GetGoogleClientSecret() string {
+	return viper.GetString("google.client_secret")
+}
+
 func GetMapBoxToken() string {
 	return viper.GetString("mapbox.token")
 }

--- a/config/getter.go
+++ b/config/getter.go
@@ -165,14 +165,6 @@ func GetJWTKey() *jwtauth.JWTAuth {
 	return jwtauth.New("HS256", []byte(viper.GetString("auth.jwt_key")), nil)
 }
 
-func GetSuperUserUsername() string {
-	return viper.GetString("auth.superuser_username")
-}
-
-func GetSuperUserPassword() string {
-	return viper.GetString("auth.superuser_password")
-}
-
 func GetTokenExpiryDuration() (time.Duration, error) {
 	timeProvider := viper.GetString("auth.jwt_expiry")
 

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,6 @@ require (
 	github.com/valyala/fasthttp v1.15.1 // indirect
 	github.com/xhit/go-str2duration/v2 v2.0.0
 	go.uber.org/zap v1.10.0
-	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b // indirect
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
 	golang.org/x/tools v0.0.0-20210104081019-d8d6ddbec6ee // indirect

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	go.uber.org/zap v1.10.0
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b // indirect
+	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
 	golang.org/x/tools v0.0.0-20210104081019-d8d6ddbec6ee // indirect
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
 	gorm.io/driver/postgres v1.0.2

--- a/go.sum
+++ b/go.sum
@@ -556,6 +556,7 @@ google.golang.org/api v0.13.0/go.mod h1:iLdEw5Ide6rF15KTC1Kkl0iskquN2gFfn9o9XIsb
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
+google.golang.org/appengine v1.6.1 h1:QzqyMA1tlu6CgqCDUtU9V+ZKhLFT2dkJuANu5QaxI3I=
 google.golang.org/appengine v1.6.1/go.mod h1:i06prIuMbXzDqacNJfV5OdTW448YApPu5ww/cMBSeb0=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,7 @@ cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSR
 cloud.google.com/go v0.44.1/go.mod h1:iSa0KzasP4Uvy3f1mN/7PiObzGgflwredwwASm/v6AU=
 cloud.google.com/go v0.44.2/go.mod h1:60680Gw3Yr4ikxnPRS/oxxkBccT6SA1yMk63TGekxKY=
 cloud.google.com/go v0.45.1/go.mod h1:RpBamKRgapWJb87xiFSdk4g1CME7QZg3uwTez+TSTjc=
+cloud.google.com/go v0.46.3 h1:AVXDdKsrtX33oR9fbCMu/+c1o8Ofjq6Ku/MInaLVg5Y=
 cloud.google.com/go v0.46.3/go.mod h1:a6bKKbmY7er1mI7TEI4lsAkts/mkhTSZK8w33B4RAg0=
 cloud.google.com/go/bigquery v1.0.1/go.mod h1:i/xbL2UlR5RvWAURpBYZTtm/cXjCha9lbfbpx4poX+o=
 cloud.google.com/go/datastore v1.0.0/go.mod h1:LXYbyblFSglQ5pkeyhO+Qmw7ukd3C+pD7TKLgZqpHYE=
@@ -469,6 +470,7 @@ golang.org/x/net v0.0.0-20201110031124-69a78807bb2b h1:uwuIcX0g4Yl1NC5XAz37xsr2l
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
+golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45 h1:SVwTIAaPC2U/AvvLNZ2a7OVsmBpC8L5BlwK1whH3hm0=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/internal/database/migrations/migrations.go
+++ b/internal/database/migrations/migrations.go
@@ -5,10 +5,8 @@ import (
 	"io/ioutil"
 	"math/rand"
 
-	"github.com/uwblueprint/shoe-project/config"
 	"github.com/uwblueprint/shoe-project/internal/database/models"
 	"github.com/uwblueprint/shoe-project/internal/location"
-	"golang.org/x/crypto/bcrypt"
 	"gorm.io/gorm"
 )
 
@@ -34,18 +32,6 @@ func DropAllTables(db *gorm.DB) error {
 		return err
 	}
 	return db.Migrator().DropTable(&models.Author{})
-}
-
-func CreateSuperUser(db *gorm.DB) error {
-	// Clear current superuser if any
-	db.Where("username = ?", config.GetSuperUserUsername()).Delete(models.User{})
-
-	hashedPassword, _ := bcrypt.GenerateFromPassword([]byte(config.GetSuperUserPassword()), 10)
-	superUser := models.User{
-		Username: config.GetSuperUserUsername(),
-		Password: string(hashedPassword),
-	}
-	return db.Create(&superUser).Error
 }
 
 func parseJson(filename string, obj interface{}) error {

--- a/internal/database/models/auth.go
+++ b/internal/database/models/auth.go
@@ -1,6 +1,8 @@
 package models
 
 import (
+	"errors"
+
 	"github.com/dgrijalva/jwt-go"
 	"gorm.io/gorm"
 )
@@ -11,6 +13,14 @@ type User struct {
 	gorm.Model
 	Email string `json:"email" gorm:"unique; not null"`
 	Hd    string `json:"hd" gorm:"not null"`
+}
+
+// BeforeCreate validates that a user email belongs to either uwblueprint or theshoeproject
+func (user *User) BeforeCreate(tx *gorm.DB) (err error) {
+	if user.Hd != "uwblueprint.org" && user.Hd != "theshoeproject.online" {
+		return errors.New("Invalid email domain")
+	}
+	return nil
 }
 
 // Claims is a custom JWT claim type

--- a/internal/database/models/auth.go
+++ b/internal/database/models/auth.go
@@ -11,8 +11,14 @@ type User struct {
 	Password string `json:"password" gorm:"not null"`
 }
 
+type UserV2 struct {
+	gorm.Model
+	Email string `json:"email" gorm:"unique; not null"`
+	Hd    string `json:"hd" gorm:"not null"`
+}
+
 // Not persisted in db
 type Claims struct {
-	Username string `json:"username"`
+	Email string `json:"email"`
 	jwt.StandardClaims
 }

--- a/internal/database/models/auth.go
+++ b/internal/database/models/auth.go
@@ -5,19 +5,16 @@ import (
 	"gorm.io/gorm"
 )
 
+// User stores all users that have ever signed in with a
+// uwblueprint or theshoeproject domains (stored in Hd field)
 type User struct {
-	gorm.Model
-	Username string `json:"username" gorm:"unique; not null"`
-	Password string `json:"password" gorm:"not null"`
-}
-
-type UserV2 struct {
 	gorm.Model
 	Email string `json:"email" gorm:"unique; not null"`
 	Hd    string `json:"hd" gorm:"not null"`
 }
 
-// Not persisted in db
+// Claims is a custom JWT claim type
+// not persisted in db
 type Claims struct {
 	Email string `json:"email"`
 	jwt.StandardClaims

--- a/restapi/api.go
+++ b/restapi/api.go
@@ -61,7 +61,7 @@ func Router(db *gorm.DB, locationFinder location.LocationFinder) (http.Handler, 
 		rest.GetHandler(r, "/story/{storyID}", api.ReturnStoryByID)
 		rest.GetHandler(r, "/authors/origin_countries", api.ReturnAllCountries)
 		rest.GetHandler(r, "/tags", api.ReturnAllUniqueTags)
-		rest.PostHandler(r, "/login", api.Login)
+		rest.GetHandler(r, "/login", api.Login)
 		rest.PostHandler(r, "/story", api.CreateStoriesFormData)
 
 		rest.GetHandler(r, "/auth/callback", api.AuthCallback)

--- a/restapi/api.go
+++ b/restapi/api.go
@@ -53,18 +53,28 @@ func Router(db *gorm.DB, locationFinder location.LocationFinder) (http.Handler, 
 
 		rest.GetHandler(r, "/auth/callback", api.AuthCallback)
 		rest.GetHandler(r, "/client_tokens", api.ReturnClientTokens)
+		rest.GetHandler(r, "/unauthorized", api.UnauthorizedPage)
+
+		// TODO: move these back to private api once https://github.com/uwblueprint/shoe-project/issues/204 is closed
+		rest.PostHandler(r, "/stories", api.CreateStories)
+		rest.PostHandler(r, "/authors", api.CreateAuthors)
 	})
 
 	// Private API
 	r.Group(func(r chi.Router) {
 		r.Use(jwtauth.Verifier(config.GetJWTKey()))
 		r.Use(jwtauth.Authenticator)
-		rest.PostHandler(r, "/stories", api.CreateStories)
-		rest.PostHandler(r, "/authors", api.CreateAuthors)
+
+		// dummy call to check auth flow
+		rest.GetHandler(r, "/checkauth", api.checkAuthDummy)
 	})
 	return r, nil
 }
 
 func (api api) health(w http.ResponseWriter, r *http.Request) render.Renderer {
 	return rest.MsgStatusOK("Hello World")
+}
+
+func (api api) checkAuthDummy(w http.ResponseWriter, r *http.Request) render.Renderer {
+	return rest.MsgStatusOK("Working!")
 }

--- a/restapi/api.go
+++ b/restapi/api.go
@@ -51,7 +51,6 @@ func Router(db *gorm.DB, locationFinder location.LocationFinder) (http.Handler, 
 		rest.PostHandler(r, "/login", api.Login)
 		rest.PostHandler(r, "/story", api.CreateStoriesFormData)
 
-		rest.GetHandler(r, "/loginv2", api.LoginV2)
 		rest.GetHandler(r, "/auth/callback", api.AuthCallback)
 		rest.GetHandler(r, "/client_tokens", api.ReturnClientTokens)
 	})

--- a/restapi/api.go
+++ b/restapi/api.go
@@ -14,6 +14,8 @@ import (
 	"github.com/uwblueprint/shoe-project/restapi/rest"
 	"github.com/uwblueprint/shoe-project/server"
 	"go.uber.org/zap"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
 	"gorm.io/gorm"
 )
 
@@ -23,6 +25,7 @@ type api struct {
 	logger         *zap.SugaredLogger
 	locationFinder location.LocationFinder
 	s3config       *aws.Config
+	oauthconfig    *oauth2.Config
 }
 
 // Router sets up the go-chi routes for the server
@@ -38,6 +41,16 @@ func Router(db *gorm.DB, locationFinder location.LocationFinder) (http.Handler, 
 			Region:           aws.String(os.Getenv("BUCKET_REGION")),
 			S3ForcePathStyle: aws.Bool(true),
 		},
+	}
+
+	api.oauthconfig = &oauth2.Config{
+		ClientID:     config.GetGoogleClientId(),
+		ClientSecret: config.GetGoogleClientSecret(),
+		RedirectURL:  "http://localhost:8900/api/auth/callback",
+		Scopes: []string{
+			"https://www.googleapis.com/auth/userinfo.email",
+		},
+		Endpoint: google.Endpoint,
 	}
 
 	// Public API

--- a/restapi/api.go
+++ b/restapi/api.go
@@ -51,6 +51,7 @@ func Router(db *gorm.DB, locationFinder location.LocationFinder) (http.Handler, 
 		rest.PostHandler(r, "/login", api.Login)
 		rest.PostHandler(r, "/story", api.CreateStoriesFormData)
 
+		rest.GetHandler(r, "/loginv2", api.LoginV2)
 		rest.GetHandler(r, "/client_tokens", api.ReturnClientTokens)
 	})
 

--- a/restapi/api.go
+++ b/restapi/api.go
@@ -52,6 +52,7 @@ func Router(db *gorm.DB, locationFinder location.LocationFinder) (http.Handler, 
 		rest.PostHandler(r, "/story", api.CreateStoriesFormData)
 
 		rest.GetHandler(r, "/loginv2", api.LoginV2)
+		rest.GetHandler(r, "/auth/callback", api.AuthCallback)
 		rest.GetHandler(r, "/client_tokens", api.ReturnClientTokens)
 	})
 

--- a/restapi/auth.go
+++ b/restapi/auth.go
@@ -12,8 +12,36 @@ import (
 	"github.com/uwblueprint/shoe-project/internal/database/models"
 	"github.com/uwblueprint/shoe-project/restapi/rest"
 	"golang.org/x/crypto/bcrypt"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
 	"gorm.io/gorm"
 )
+
+func (api api) LoginV2(w http.ResponseWriter, r *http.Request) render.Renderer {
+	oauthconfig := &oauth2.Config{
+		ClientID:     config.GetGoogleClientId(),
+		ClientSecret: config.GetGoogleClientSecret(),
+		RedirectURL:  "http://localhost:8900/api/auth/callback",
+		Scopes: []string{
+			"https://www.googleapis.com/auth/userinfo.email",
+		},
+		Endpoint: google.Endpoint,
+	}
+
+	// TODO: randomize state param
+	var url string
+	url = oauthconfig.AuthCodeURL("try")
+	http.Redirect(w, r, url, http.StatusTemporaryRedirect)
+
+	// TODO: figure out to stop html char escaping in url in json response
+	// bf := bytes.NewBuffer([]byte{})
+	// jsonEncoder := json.NewEncoder(bf)
+	// jsonEncoder.SetEscapeHTML(false)
+	// jsonEncoder.Encode(url)
+	// fmt.Println(url)
+
+	return rest.JSONStatusOK(url)
+}
 
 func (api api) Login(w http.ResponseWriter, r *http.Request) render.Renderer {
 	var user models.User

--- a/restapi/redirects.go
+++ b/restapi/redirects.go
@@ -1,0 +1,12 @@
+package restapi
+
+import (
+	"net/http"
+
+	"github.com/go-chi/render"
+	"github.com/uwblueprint/shoe-project/restapi/rest"
+)
+
+func (api api) UnauthorizedPage(w http.ResponseWriter, r *http.Request) render.Renderer {
+	return rest.JSONStatusOK("Unauthorized!")
+}

--- a/ui/src/hooks/auth.tsx
+++ b/ui/src/hooks/auth.tsx
@@ -26,7 +26,7 @@ export function useProvideAuth(): AuthContextType {
 
   // TODO: Write signout function
   // eslint-disable-next-line @typescript-eslint/no-empty-function
-  const signout = () => { };
+  const signout = () => {};
 
   return {
     user,
@@ -47,13 +47,13 @@ export const PrivateRoute: React.FC<RouteProps> = ({ children, ...rest }) => {
         auth.user ? (
           children
         ) : (
-            <Redirect
-              to={{
-                pathname: "/login",
-                state: { from: location },
-              }}
-            />
-          )
+          <Redirect
+            to={{
+              pathname: "/login",
+              state: { from: location },
+            }}
+          />
+        )
       }
     />
   );

--- a/ui/src/hooks/auth.tsx
+++ b/ui/src/hooks/auth.tsx
@@ -21,13 +21,12 @@ export function useProvideAuth(): AuthContextType {
 
   // TODO: Write signin function
   const signin = () => {
-    setUser({ username: "Abhijeet" });
-    console.log("ABHIJEET LOGGED IN");
+    setUser({ email: "abhijeet@uwblueprint.org" });
   };
 
   // TODO: Write signout function
   // eslint-disable-next-line @typescript-eslint/no-empty-function
-  const signout = () => {};
+  const signout = () => { };
 
   return {
     user,
@@ -48,13 +47,13 @@ export const PrivateRoute: React.FC<RouteProps> = ({ children, ...rest }) => {
         auth.user ? (
           children
         ) : (
-          <Redirect
-            to={{
-              pathname: "/login",
-              state: { from: location },
-            }}
-          />
-        )
+            <Redirect
+              to={{
+                pathname: "/login",
+                state: { from: location },
+              }}
+            />
+          )
       }
     />
   );

--- a/ui/src/types/index.tsx
+++ b/ui/src/types/index.tsx
@@ -39,5 +39,5 @@ export interface Tokens {
 }
 
 export interface User extends Partial<Model> {
-  username: string;
+  email: string;
 }


### PR DESCRIPTION
Closes: https://github.com/uwblueprint/shoe-project/issues/204

- Set up project on google api console
- Create `/login` endpoint
  - Sets `state` and redirects to google oauth endpoint
  - Google oauth set up to call our callback endpoint below
- Create `/auth/callback` endpoint
  - Checks state 
  - Checks email domain
  - Retrieves user email
  - Encodes + returns jwt token (setting jwt token in local session storage is for next pr)
- If unauthorised, redirects to vanilla `/unauthorized` endpoint
- Updates some of the frontend boilerplate setup (due to changes in `User` model)

<b>To reviewers:</b>
Feel free to tophat by going to `localhost:8900/api/login` (if you're unable to login to Google you might need to be added to our project on the google console -- please slack me!)