### PR TITLE
feat: Upload Story Page: Success, Loading, and Error States

### DIFF
--- a/restapi/stories.go
+++ b/restapi/stories.go
@@ -35,7 +35,7 @@ func init() {
 func (api api) ReturnAllStories(w http.ResponseWriter, r *http.Request) render.Renderer {
 	var stories []models.Story
 
-	err := api.database.Find(&stories).Error
+	err := api.database.Where("is_visible = true").Find(&stories).Error
 	if err != nil {
 		return rest.ErrInternal(api.logger, err)
 	}

--- a/restapi/stories.go
+++ b/restapi/stories.go
@@ -35,7 +35,7 @@ func init() {
 func (api api) ReturnAllStories(w http.ResponseWriter, r *http.Request) render.Renderer {
 	var stories []models.Story
 
-	err := api.database.Where("is_visible = true").Find(&stories).Error
+	err := api.database.Find(&stories).Error
 	if err != nil {
 		return rest.ErrInternal(api.logger, err)
 	}

--- a/ui/src/pages/Upload.tsx
+++ b/ui/src/pages/Upload.tsx
@@ -6,8 +6,10 @@ import {
   InputLabel,
   MenuItem,
   Select,
+  Snackbar,
   TextField,
 } from "@material-ui/core/";
+import Alert from "@material-ui/lab/Alert";
 import Autocomplete from "@material-ui/lab/Autocomplete";
 import { DropzoneArea } from "material-ui-dropzone";
 import * as React from "react";
@@ -87,6 +89,12 @@ const StyledTags = styled(Autocomplete)`
   }
 `;
 
+const StyledButton = styled(Button)`
+  && {
+    width: 30vw;
+    margin-left: 24px;
+  }
+`;
 const StyledBackgroundColor = styled.div`
   background-color: ${colors.white};
   width: 40vw;
@@ -106,6 +114,7 @@ interface TagParameters {
 
 export const Upload: React.FC = () => {
   const [tagArray, setTagArrayValues] = useState([]);
+  const [open, setOpen] = useState(false);
 
   const { data: tagOptions, error } = useSWR<string[]>("/api/tags");
 
@@ -155,8 +164,16 @@ export const Upload: React.FC = () => {
     });
   };
 
+  const handleAlertClose = (event, reason) => {
+    if (reason === "clickaway") {
+      return;
+    }
+    setOpen(false);
+  };
+
   const handleSubmit = (event) => {
     event.preventDefault();
+    setOpen(true);
     const formData = new FormData();
     for (const key in formInput) {
       formData.append(key, formInput[key]);
@@ -172,7 +189,9 @@ export const Upload: React.FC = () => {
       redirect: "follow",
     })
       .then((response) => response.text())
-      .then((result) => console.log(result))
+      .then((result) => {
+        console.log(result);
+      })
       .catch((error) => console.log("Error: ", error));
   };
 
@@ -377,9 +396,19 @@ export const Upload: React.FC = () => {
               }}
             />
           </StyledBackgroundColor>
-          <Button color="primary" type="submit" variant="contained">
+
+          <StyledButton color="primary" type="submit" variant="contained">
             Submit Story
-          </Button>
+          </StyledButton>
+          <Snackbar
+            open={open}
+            autoHideDuration={5000}
+            onClose={handleAlertClose}
+          >
+            <Alert onClose={handleAlertClose} severity="success">
+              Story uploaded successfully!
+            </Alert>
+          </Snackbar>
         </FormControl>
       </form>
     </StyledGrid>

--- a/ui/src/pages/Upload.tsx
+++ b/ui/src/pages/Upload.tsx
@@ -1,15 +1,19 @@
 import {
   Button,
   Chip,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
   FormControl,
   Grid,
   InputLabel,
   MenuItem,
   Select,
-  Snackbar,
   TextField,
 } from "@material-ui/core/";
-import Alert from "@material-ui/lab/Alert";
+// import CircularProgress from "@material-ui/core/CircularProgress";
 import Autocomplete from "@material-ui/lab/Autocomplete";
 import { DropzoneArea } from "material-ui-dropzone";
 import * as React from "react";
@@ -114,7 +118,7 @@ interface TagParameters {
 
 export const Upload: React.FC = () => {
   const [tagArray, setTagArrayValues] = useState([]);
-  const [open, setOpen] = useState(false);
+  const [dialogOpenState, setDialogOpenState] = useState(false);
 
   const { data: tagOptions, error } = useSWR<string[]>("/api/tags");
 
@@ -164,16 +168,28 @@ export const Upload: React.FC = () => {
     });
   };
 
-  const handleAlertClose = (event, reason) => {
-    if (reason === "clickaway") {
-      return;
-    }
-    setOpen(false);
+  const handleDialogClose = () => {
+    setDialogOpenState(false);
   };
 
+  const handleDialogAgree = () => {
+    handleDialogClose();
+  };
+
+  const handleDialogDisagree = () => {
+    handleDialogClose();
+  };
+
+  function storySubmitDialog(result) {
+    const resultMessage = JSON.parse(result).message;
+    if (resultMessage === "Story Added Successfully") {
+      setDialogOpenState(true);
+    } else {
+      return <div>ERROR ADDING STORY</div>;
+    }
+  }
   const handleSubmit = (event) => {
     event.preventDefault();
-    setOpen(true);
     const formData = new FormData();
     for (const key in formInput) {
       formData.append(key, formInput[key]);
@@ -190,7 +206,7 @@ export const Upload: React.FC = () => {
     })
       .then((response) => response.text())
       .then((result) => {
-        console.log(result);
+        storySubmitDialog(result);
       })
       .catch((error) => console.log("Error: ", error));
   };
@@ -400,15 +416,29 @@ export const Upload: React.FC = () => {
           <StyledButton color="primary" type="submit" variant="contained">
             Submit Story
           </StyledButton>
-          <Snackbar
-            open={open}
-            autoHideDuration={5000}
-            onClose={handleAlertClose}
+          <Dialog
+            open={dialogOpenState}
+            onClose={handleDialogClose}
+            aria-labelledby="alert-dialog-title"
+            aria-describedby="alert-dialog-description"
           >
-            <Alert onClose={handleAlertClose} severity="success">
-              Story uploaded successfully!
-            </Alert>
-          </Snackbar>
+            <DialogTitle id="alert-dialog-title">
+              {"Story Upload Success!"}
+            </DialogTitle>
+            <DialogContent>
+              <DialogContentText id="alert-dialog-description">
+                Your story is now available on the All Stories Dashboard!
+              </DialogContentText>
+            </DialogContent>
+            <DialogActions>
+              <Button onClick={handleDialogDisagree} color="primary">
+                Return to Dashboard
+              </Button>
+              <Button onClick={handleDialogAgree} color="primary">
+                Continue Uploading
+              </Button>
+            </DialogActions>
+          </Dialog>
         </FormControl>
       </form>
     </StyledGrid>

--- a/ui/src/pages/Upload.tsx
+++ b/ui/src/pages/Upload.tsx
@@ -11,9 +11,11 @@ import {
   InputLabel,
   MenuItem,
   Select,
+  Snackbar,
   TextField,
 } from "@material-ui/core/";
-// import CircularProgress from "@material-ui/core/CircularProgress";
+import LinearProgress from "@material-ui/core/LinearProgress";
+import Alert from "@material-ui/lab/Alert";
 import Autocomplete from "@material-ui/lab/Autocomplete";
 import { DropzoneArea } from "material-ui-dropzone";
 import * as React from "react";
@@ -106,6 +108,9 @@ const StyledBackgroundColor = styled.div`
   margin-bottom: 24px;
 `;
 
+const StyledLinearProgress = styled(LinearProgress)`
+  margin-top: 24px;
+`;
 interface InputProps {
   onKeyDown: (
     event: KeyboardEvent<HTMLInputElement | HTMLTextAreaElement>
@@ -119,7 +124,8 @@ interface TagParameters {
 export const Upload: React.FC = () => {
   const [tagArray, setTagArrayValues] = useState([]);
   const [dialogOpenState, setDialogOpenState] = useState(false);
-
+  const [uploadErrorState, setErrorOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
   const { data: tagOptions, error } = useSWR<string[]>("/api/tags");
 
   const [formInput, setFormInput] = useReducer(
@@ -159,6 +165,14 @@ export const Upload: React.FC = () => {
       default:
     }
   };
+
+  const setErrorUploadingState = (event, reason) => {
+    if (reason === "clickaway") {
+      return;
+    }
+    setErrorOpen(false);
+  };
+
   const handleChange = (
     event?: React.ChangeEvent<{ name?: string; value: unknown }>
   ) => {
@@ -181,15 +195,17 @@ export const Upload: React.FC = () => {
   };
 
   function storySubmitDialog(result) {
+    setLoading(false);
     const resultMessage = JSON.parse(result).message;
     if (resultMessage === "Story Added Successfully") {
       setDialogOpenState(true);
     } else {
-      return <div>ERROR ADDING STORY</div>;
+      setErrorOpen(true);
     }
   }
   const handleSubmit = (event) => {
     event.preventDefault();
+    setLoading(true);
     const formData = new FormData();
     for (const key in formInput) {
       formData.append(key, formInput[key]);
@@ -214,233 +230,249 @@ export const Upload: React.FC = () => {
   if (error) return <div>Error fetching tags!</div>;
 
   return (
-    <StyledGrid container justify="center" alignContent="center">
-      <form onSubmit={handleSubmit}>
-        <FormControl>
-          <StyledBackgroundColor>
-            <UploadStoriesHeading>Story Information</UploadStoriesHeading>
-            <UploadLabelsText>Title</UploadLabelsText>
-            <StyledTextField
-              onChange={handleChange}
-              variant="outlined"
-              required
-              id="story-title"
-              name="title"
-              label="Enter story title"
-              placeholder="Lorem ipsum"
-            />
-            <UploadLabelsText>Summary</UploadLabelsText>
-            <StyledTextField
-              onChange={handleChange}
-              multiline
-              placeholder="Enter additional information here"
-              variant="outlined"
-              required
-              id="story-summary"
-              name="summary"
-              label="Enter story summary"
-            />
-            <UploadLabelsText>Story</UploadLabelsText>
-            <StyledTextField
-              onChange={handleChange}
-              multiline
-              variant="outlined"
-              placeholder="Lorem ipsum dolor sit amet, consectet ui i iadipiscing elit"
-              rows={8}
-              required
-              inputProps={{
-                name: "content",
-                id: "story-content",
-              }}
-              label="Enter story"
-            />
-          </StyledBackgroundColor>
-          <StyledBackgroundColor>
-            <UploadStoriesHeading>Author Information</UploadStoriesHeading>
-            <UploadLabelsText>First Name</UploadLabelsText>
-            <StyledTextField
-              onChange={handleChange}
-              variant="outlined"
-              required
-              id="author-first-name"
-              name="author_first_name"
-              label="Enter author's first name"
-              placeholder="Lorem ipsum"
-            />
-            <UploadLabelsText>Last Name</UploadLabelsText>
-            <StyledTextField
-              onChange={handleChange}
-              variant="outlined"
-              required
-              id="author-last-name"
-              name="author_last_name"
-              label="Enter author's last name"
-              placeholder="Lorem ipsum"
-            />
-            <UploadLabelsText>Biography</UploadLabelsText>
-            <StyledTextField
-              variant="outlined"
-              onChange={handleChange}
-              multiline
-              placeholder="Enter additional information here"
-              rows={4}
-              id="author-bio"
-              name="bio"
-              label="Enter author biography"
-            />
-          </StyledBackgroundColor>
+    <>
+      <StyledGrid container justify="center" alignContent="center">
+        <form onSubmit={handleSubmit}>
+          <FormControl>
+            <StyledBackgroundColor>
+              <UploadStoriesHeading>Story Information</UploadStoriesHeading>
+              <UploadLabelsText>Title</UploadLabelsText>
+              <StyledTextField
+                onChange={handleChange}
+                variant="outlined"
+                required
+                id="story-title"
+                name="title"
+                label="Enter story title"
+                placeholder="Lorem ipsum"
+              />
+              <UploadLabelsText>Summary</UploadLabelsText>
+              <StyledTextField
+                onChange={handleChange}
+                multiline
+                placeholder="Enter additional information here"
+                variant="outlined"
+                required
+                id="story-summary"
+                name="summary"
+                label="Enter story summary"
+              />
+              <UploadLabelsText>Story</UploadLabelsText>
+              <StyledTextField
+                onChange={handleChange}
+                multiline
+                variant="outlined"
+                placeholder="Lorem ipsum dolor sit amet, consectet ui i iadipiscing elit"
+                rows={8}
+                required
+                inputProps={{
+                  name: "content",
+                  id: "story-content",
+                }}
+                label="Enter story"
+              />
+            </StyledBackgroundColor>
+            <StyledBackgroundColor>
+              <UploadStoriesHeading>Author Information</UploadStoriesHeading>
+              <UploadLabelsText>First Name</UploadLabelsText>
+              <StyledTextField
+                onChange={handleChange}
+                variant="outlined"
+                required
+                id="author-first-name"
+                name="author_first_name"
+                label="Enter author's first name"
+                placeholder="Lorem ipsum"
+              />
+              <UploadLabelsText>Last Name</UploadLabelsText>
+              <StyledTextField
+                onChange={handleChange}
+                variant="outlined"
+                required
+                id="author-last-name"
+                name="author_last_name"
+                label="Enter author's last name"
+                placeholder="Lorem ipsum"
+              />
+              <UploadLabelsText>Biography</UploadLabelsText>
+              <StyledTextField
+                variant="outlined"
+                onChange={handleChange}
+                multiline
+                placeholder="Enter additional information here"
+                rows={4}
+                id="author-bio"
+                name="bio"
+                label="Enter author biography"
+              />
+            </StyledBackgroundColor>
 
-          <StyledBackgroundColor>
-            <UploadStoriesHeading>Additional Information</UploadStoriesHeading>
-            <FormControl>
-              <UploadLabelsText>Country of Origin</UploadLabelsText>
-              <StyledInputLabel id="Country of Origin">
-                Enter story&#39;s country of origin
+            <StyledBackgroundColor>
+              <UploadStoriesHeading>
+                Additional Information
+              </UploadStoriesHeading>
+              <FormControl>
+                <UploadLabelsText>Country of Origin</UploadLabelsText>
+                <StyledInputLabel id="Country of Origin">
+                  Enter story&#39;s country of origin
+                </StyledInputLabel>
+                <StyledSelect
+                  variant="outlined"
+                  value={formInput.author_country}
+                  onChange={handleChange}
+                  inputProps={{
+                    name: "author_country",
+                    id: "select-label-country",
+                  }}
+                >
+                  {countriesList.map((country) => (
+                    <StyledMenuItem key={country.code} value={country.name}>
+                      {country.name}
+                    </StyledMenuItem>
+                  ))}
+                </StyledSelect>
+              </FormControl>
+              <UploadLabelsText>Current City</UploadLabelsText>
+              <StyledInputLabel id="Current Location">
+                Enter where story was written
               </StyledInputLabel>
               <StyledSelect
                 variant="outlined"
-                value={formInput.author_country}
+                value={formInput.current_city}
                 onChange={handleChange}
                 inputProps={{
-                  name: "author_country",
-                  id: "select-label-country",
+                  name: "current_city",
+                  id: "select-label-city",
                 }}
               >
-                {countriesList.map((country) => (
-                  <StyledMenuItem key={country.code} value={country.name}>
-                    {country.name}
-                  </StyledMenuItem>
-                ))}
+                <StyledMenuItem value={"Toronto"}>Toronto</StyledMenuItem>
+                <StyledMenuItem value={"Calgary"}>Calgary</StyledMenuItem>
+                <StyledMenuItem value={"Vancouver"}>Vancouver</StyledMenuItem>
+                <StyledMenuItem value={"Halifax"}>Halifax</StyledMenuItem>
+                <StyledMenuItem value={"Thunder Bay"}>
+                  Thunder Bay
+                </StyledMenuItem>
               </StyledSelect>
-            </FormControl>
-            <UploadLabelsText>Current City</UploadLabelsText>
-            <StyledInputLabel id="Current Location">
-              Enter where story was written
-            </StyledInputLabel>
-            <StyledSelect
-              variant="outlined"
-              value={formInput.current_city}
-              onChange={handleChange}
-              inputProps={{
-                name: "current_city",
-                id: "select-label-city",
-              }}
-            >
-              <StyledMenuItem value={"Toronto"}>Toronto</StyledMenuItem>
-              <StyledMenuItem value={"Calgary"}>Calgary</StyledMenuItem>
-              <StyledMenuItem value={"Vancouver"}>Vancouver</StyledMenuItem>
-              <StyledMenuItem value={"Halifax"}>Halifax</StyledMenuItem>
-              <StyledMenuItem value={"Thunder Bay"}>Thunder Bay</StyledMenuItem>
-            </StyledSelect>
-            <FormControl>
-              <UploadLabelsText>Year Published</UploadLabelsText>
-              <StyledSelect
+              <FormControl>
+                <UploadLabelsText>Year Published</UploadLabelsText>
+                <StyledSelect
+                  variant="outlined"
+                  value={formInput.year}
+                  onChange={handleChange}
+                  defaultValue={"2021"}
+                  inputProps={{
+                    name: "year",
+                    id: "select-label-year",
+                  }}
+                >
+                  <StyledMenuItem value={"2021"}>2021</StyledMenuItem>
+                  <StyledMenuItem value={"2020"}>2020</StyledMenuItem>
+                  <StyledMenuItem value={"2019"}>2019</StyledMenuItem>
+                </StyledSelect>
+              </FormControl>
+              <FormControl>
+                <UploadLabelsText>Tags</UploadLabelsText>
+                <StyledTags
+                  autoHighlight
+                  multiple
+                  id="tags-outlined"
+                  name="tags"
+                  freeSolo
+                  options={tagOptions ? tagOptions : [""]}
+                  filterSelectedOptions
+                  onChange={(_, newValue) => setTagArrayValues(newValue)}
+                  value={tagArray ? tagArray : [""]}
+                  renderTags={(value, getTagProps) =>
+                    value.map((option, index) => (
+                      <Chip
+                        key={option}
+                        variant="outlined"
+                        label={option}
+                        {...getTagProps({ index })}
+                      />
+                    ))
+                  }
+                  renderInput={(params: TagParameters) => {
+                    params.inputProps.onKeyDown = handleKeyDown;
+                    return (
+                      <TextField
+                        {...params}
+                        variant="outlined"
+                        label="Shoe Tags"
+                        placeholder="Select Tags"
+                      ></TextField>
+                    );
+                  }}
+                />
+              </FormControl>
+            </StyledBackgroundColor>
+            <StyledBackgroundColor>
+              <UploadStoriesHeading>Multimedia</UploadStoriesHeading>
+              <ImageContainer>
+                <UploadLabelsText>Add Image</UploadLabelsText>
+                <StyledDropzoneArea
+                  showFileNames
+                  acceptedFiles={["image/*"]}
+                  filesLimit={1}
+                  dropzoneText={"Drag image here or select from device"}
+                  onChange={(files) => {
+                    setImage(files);
+                  }}
+                />
+              </ImageContainer>
+              <UploadLabelsText>Video Link</UploadLabelsText>
+              <StyledTextField
+                onChange={handleChange}
                 variant="outlined"
-                value={formInput.year}
-                onChange={handleChange}
-                defaultValue={"2021"}
+                id="video-link"
+                label="Video Link"
+                placeholder="www.youtube.com/link"
                 inputProps={{
-                  name: "year",
-                  id: "select-label-year",
-                }}
-              >
-                <StyledMenuItem value={"2021"}>2021</StyledMenuItem>
-                <StyledMenuItem value={"2020"}>2020</StyledMenuItem>
-                <StyledMenuItem value={"2019"}>2019</StyledMenuItem>
-              </StyledSelect>
-            </FormControl>
-            <FormControl>
-              <UploadLabelsText>Tags</UploadLabelsText>
-              <StyledTags
-                autoHighlight
-                multiple
-                id="tags-outlined"
-                name="tags"
-                freeSolo
-                options={tagOptions ? tagOptions : [""]}
-                filterSelectedOptions
-                onChange={(_, newValue) => setTagArrayValues(newValue)}
-                value={tagArray ? tagArray : [""]}
-                renderTags={(value, getTagProps) =>
-                  value.map((option, index) => (
-                    <Chip
-                      key={option}
-                      variant="outlined"
-                      label={option}
-                      {...getTagProps({ index })}
-                    />
-                  ))
-                }
-                renderInput={(params: TagParameters) => {
-                  params.inputProps.onKeyDown = handleKeyDown;
-                  return (
-                    <TextField
-                      {...params}
-                      variant="outlined"
-                      label="Shoe Tags"
-                      placeholder="Select Tags"
-                    ></TextField>
-                  );
+                  name: "video_url",
+                  id: "input-video-link",
                 }}
               />
-            </FormControl>
-          </StyledBackgroundColor>
-          <StyledBackgroundColor>
-            <UploadStoriesHeading>Multimedia</UploadStoriesHeading>
-            <ImageContainer>
-              <UploadLabelsText>Add Image</UploadLabelsText>
-              <StyledDropzoneArea
-                showFileNames
-                acceptedFiles={["image/*"]}
-                filesLimit={1}
-                dropzoneText={"Drag image here or select from device"}
-                onChange={(files) => {
-                  setImage(files);
-                }}
-              />
-            </ImageContainer>
-            <UploadLabelsText>Video Link</UploadLabelsText>
-            <StyledTextField
-              onChange={handleChange}
-              variant="outlined"
-              id="video-link"
-              label="Video Link"
-              placeholder="www.youtube.com/link"
-              inputProps={{
-                name: "video_url",
-                id: "input-video-link",
-              }}
-            />
-          </StyledBackgroundColor>
+            </StyledBackgroundColor>
 
-          <StyledButton color="primary" type="submit" variant="contained">
-            Submit Story
-          </StyledButton>
-          <Dialog
-            open={dialogOpenState}
-            onClose={handleDialogClose}
-            aria-labelledby="alert-dialog-title"
-            aria-describedby="alert-dialog-description"
-          >
-            <DialogTitle id="alert-dialog-title">
-              {"Story Upload Success!"}
-            </DialogTitle>
-            <DialogContent>
-              <DialogContentText id="alert-dialog-description">
-                Your story is now available on the All Stories Dashboard!
-              </DialogContentText>
-            </DialogContent>
-            <DialogActions>
-              <Button onClick={handleDialogDisagree} color="primary">
-                Return to Dashboard
-              </Button>
-              <Button onClick={handleDialogAgree} color="primary">
-                Continue Uploading
-              </Button>
-            </DialogActions>
-          </Dialog>
-        </FormControl>
-      </form>
-    </StyledGrid>
+            <StyledButton color="primary" type="submit" variant="contained">
+              Submit Story
+            </StyledButton>
+            <Snackbar
+              open={uploadErrorState}
+              autoHideDuration={5000}
+              onClose={setErrorUploadingState}
+            >
+              <Alert variant="filled" severity="error">
+                Error uploading story!
+              </Alert>
+            </Snackbar>
+            <Dialog
+              open={dialogOpenState}
+              onClose={handleDialogClose}
+              aria-labelledby="alert-dialog-title"
+              aria-describedby="alert-dialog-description"
+            >
+              <DialogTitle id="alert-dialog-title">
+                {"Story Upload Success!"}
+              </DialogTitle>
+              <DialogContent>
+                <DialogContentText id="alert-dialog-description">
+                  Your story is now available on the All Stories Dashboard!
+                </DialogContentText>
+              </DialogContent>
+              <DialogActions>
+                <Button onClick={handleDialogDisagree} color="primary">
+                  Return to Dashboard
+                </Button>
+                <Button onClick={handleDialogAgree} color="primary">
+                  Continue Uploading
+                </Button>
+              </DialogActions>
+            </Dialog>
+          </FormControl>
+        </form>
+      </StyledGrid>
+      {loading ? <StyledLinearProgress /> : null}
+    </>
   );
 };

--- a/ui/src/pages/Upload.tsx
+++ b/ui/src/pages/Upload.tsx
@@ -9,12 +9,12 @@ import {
   FormControl,
   Grid,
   InputLabel,
+  LinearProgress,
   MenuItem,
   Select,
   Snackbar,
   TextField,
 } from "@material-ui/core/";
-import LinearProgress from "@material-ui/core/LinearProgress";
 import Alert from "@material-ui/lab/Alert";
 import Autocomplete from "@material-ui/lab/Autocomplete";
 import { DropzoneArea } from "material-ui-dropzone";
@@ -111,6 +111,7 @@ const StyledBackgroundColor = styled.div`
 const StyledLinearProgress = styled(LinearProgress)`
   margin-top: 24px;
 `;
+
 interface InputProps {
   onKeyDown: (
     event: KeyboardEvent<HTMLInputElement | HTMLTextAreaElement>
@@ -122,11 +123,12 @@ interface TagParameters {
 }
 
 export const Upload: React.FC = () => {
+  const { data: tagOptions, error } = useSWR<string[]>("/api/tags");
   const [tagArray, setTagArrayValues] = useState([]);
+  //handleSubmit component states
   const [dialogOpenState, setDialogOpenState] = useState(false);
   const [uploadErrorState, setErrorOpen] = useState(false);
   const [loading, setLoading] = useState(false);
-  const { data: tagOptions, error } = useSWR<string[]>("/api/tags");
 
   const [formInput, setFormInput] = useReducer(
     (state, newState) => ({ ...state, ...newState }),
@@ -194,7 +196,7 @@ export const Upload: React.FC = () => {
     handleDialogClose();
   };
 
-  function storySubmitDialog(result) {
+  const storySubmitDialog = (result) => {
     setLoading(false);
     const resultMessage = JSON.parse(result).message;
     if (resultMessage === "Story Added Successfully") {
@@ -202,7 +204,7 @@ export const Upload: React.FC = () => {
     } else {
       setErrorOpen(true);
     }
-  }
+  };
   const handleSubmit = (event) => {
     event.preventDefault();
     setLoading(true);

--- a/ui/src/pages/Upload.tsx
+++ b/ui/src/pages/Upload.tsx
@@ -125,6 +125,7 @@ interface TagParameters {
 export const Upload: React.FC = () => {
   const { data: tagOptions, error } = useSWR<string[]>("/api/tags");
   const [tagArray, setTagArrayValues] = useState([]);
+  const [disabled, setDisabled] = useState(false);
   //handleSubmit component states
   const [dialogOpenState, setDialogOpenState] = useState(false);
   const [uploadErrorState, setErrorOpen] = useState(false);
@@ -198,6 +199,7 @@ export const Upload: React.FC = () => {
 
   const storySubmitDialog = (result) => {
     setLoading(false);
+    setDisabled(false);
     const resultMessage = JSON.parse(result).message;
     if (resultMessage === "Story Added Successfully") {
       setDialogOpenState(true);
@@ -208,6 +210,7 @@ export const Upload: React.FC = () => {
   const handleSubmit = (event) => {
     event.preventDefault();
     setLoading(true);
+    setDisabled(true);
     const formData = new FormData();
     for (const key in formInput) {
       formData.append(key, formInput[key]);
@@ -436,7 +439,12 @@ export const Upload: React.FC = () => {
               />
             </StyledBackgroundColor>
 
-            <StyledButton color="primary" type="submit" variant="contained">
+            <StyledButton
+              disabled={disabled}
+              color="primary"
+              type="submit"
+              variant="contained"
+            >
               Submit Story
             </StyledButton>
             <Snackbar
@@ -452,7 +460,7 @@ export const Upload: React.FC = () => {
               open={dialogOpenState}
               onClose={handleDialogClose}
               aria-labelledby="alert-dialog-title"
-              aria-describedby="alert-dialog-description"
+              aria-describedby="alert-dialogd-description"
             >
               <DialogTitle id="alert-dialog-title">
                 {"Story Upload Success!"}


### PR DESCRIPTION
Add in three UI states on ```handleSubmit```
**Loading**
![image](https://user-images.githubusercontent.com/19617248/110425598-9aff9400-8072-11eb-8f3c-849f8fd13571.png)
<br/>
**Error**
![image](https://user-images.githubusercontent.com/19617248/110425574-90dd9580-8072-11eb-8e98-a8a3cf537479.png)
<br/>
**Success**
![image](https://user-images.githubusercontent.com/19617248/110425620-a2bf3880-8072-11eb-9ae2-bdb39b5b5b73.png)

We can route the success dialog to the appropriate places once the pages are refined.

<h5> Todo: Hi-Fi Styling for states (right now just default MUI) </h5>
Closes #230 