### PR TITLE
feat: add max file size limit on upload

### DIFF
--- a/ui/src/pages/Upload.tsx
+++ b/ui/src/pages/Upload.tsx
@@ -506,6 +506,7 @@ export const Upload: React.FC = () => {
                 <UploadLabelsText>Add Image</UploadLabelsText>
                 <StyledDropzoneArea
                   showFileNames
+                  maxFileSize={7000000}
                   acceptedFiles={["image/*"]}
                   filesLimit={1}
                   dropzoneText={"Drag image here or select from device"}

--- a/ui/src/pages/Upload.tsx
+++ b/ui/src/pages/Upload.tsx
@@ -509,7 +509,9 @@ export const Upload: React.FC = () => {
                   maxFileSize={7000000}
                   acceptedFiles={["image/*"]}
                   filesLimit={1}
-                  dropzoneText={"Drag image here or select from device"}
+                  dropzoneText={
+                    "Drag image here or select from device - file limit is 7MB."
+                  }
                   onChange={(files) => {
                     setImage(files);
                   }}

--- a/ui/src/pages/Upload.tsx
+++ b/ui/src/pages/Upload.tsx
@@ -510,7 +510,7 @@ export const Upload: React.FC = () => {
                   acceptedFiles={["image/*"]}
                   filesLimit={1}
                   dropzoneText={
-                    "Drag image here or select from device - file limit is 7MB."
+                    "Drag image here or select from device - Maximum Supported File Size is 7MB."
                   }
                   onChange={(files) => {
                     setImage(files);

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -5739,7 +5739,7 @@ ms@2.1.2:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-mui-virtualized-table@3.0.0:
+mui-virtualized-table@3.0.0-6:
   version "3.0.0-6"
   resolved "https://registry.yarnpkg.com/mui-virtualized-table/-/mui-virtualized-table-3.0.0-6.tgz#9ceae2b962b6a7ffd782de212c85fe282e9af0b4"
   integrity sha512-qZdsiXRxqNlM0bmuJWEmXLFEHsSM1NPxhvNE2ds5NWYM+QLZ1pbnnva0yC7Oo+g7ieCmkK6tJYd89FSOUaM1mg==


### PR DESCRIPTION
### Description

Set limit on file size upload for #279 . To test, go to `/upload` download a file > 7MB (i.e. https://effigis.com/en/solutions/satellite-images/satellite-image-samples/) Should get the following error: 
![image](https://user-images.githubusercontent.com/19617248/113488138-2873af80-948a-11eb-9283-59d2b979dfbc.png)
![image](https://user-images.githubusercontent.com/19617248/113488800-480cd700-948e-11eb-860b-166960f8f0da.png)

Closes #278 