### PR TITLE
fix: don't open story on toggle/check

### DIFF
--- a/ui/src/components/VirtualizedTable.tsx
+++ b/ui/src/components/VirtualizedTable.tsx
@@ -71,6 +71,9 @@ export function VirtualizedTable({
             orderDirection={order}
             includeHeaders
             onCellClick={(e, { rowData }) => {
+              if (e.target.type === "checkbox") {
+                return;
+              }
               const id: number = rowData?.ID;
               if (id) {
                 setClickedRow(id);


### PR DESCRIPTION
Won't open the story when the row is clicked but is on the checkbox/switch. Will open the story on all other fields. 
![bf6a6efc-d93a-44ae-ae3d-cfe8d0730b95](https://user-images.githubusercontent.com/19617248/113920095-591d5700-97b2-11eb-8a9a-a4696ff1dd16.gif)
