### PR TITLE
Generate Cookie when Domain is not HTTPS

### DIFF
--- a/restapi/auth.go
+++ b/restapi/auth.go
@@ -73,7 +73,9 @@ func generateJWTToken(email string, w http.ResponseWriter) error {
 		return err
 	}
 
-	secure := (config.GetMode() == config.MODE_PROD)
+	// TODO: change this back when we start using https
+	// secure := (config.GetMode() == config.MODE_PROD)
+	secure := false
 
 	cookie := http.Cookie{Name: "jwt", Value: signedToken, Expires: expiration, HttpOnly: true, Secure: false, Path: "/api"}
 	http.SetCookie(w, &cookie)

--- a/restapi/auth.go
+++ b/restapi/auth.go
@@ -77,7 +77,7 @@ func generateJWTToken(email string, w http.ResponseWriter) error {
 	// secure := (config.GetMode() == config.MODE_PROD)
 	secure := false
 
-	cookie := http.Cookie{Name: "jwt", Value: signedToken, Expires: expiration, HttpOnly: true, Secure: false, Path: "/api"}
+	cookie := http.Cookie{Name: "jwt", Value: signedToken, Expires: expiration, HttpOnly: true, Secure: secure, Path: "/api"}
 	http.SetCookie(w, &cookie)
 
 	return nil

--- a/restapi/auth.go
+++ b/restapi/auth.go
@@ -75,7 +75,7 @@ func generateJWTToken(email string, w http.ResponseWriter) error {
 
 	secure := (config.GetMode() == config.MODE_PROD)
 
-	cookie := http.Cookie{Name: "jwt", Value: signedToken, Expires: expiration, HttpOnly: true, Secure: secure, Path: "/api"}
+	cookie := http.Cookie{Name: "jwt", Value: signedToken, Expires: expiration, HttpOnly: true, Secure: false, Path: "/api"}
 	http.SetCookie(w, &cookie)
 
 	return nil


### PR DESCRIPTION
Since map.theshoeproject.online is not https yet (still in talks with the client) the jwt token doesn't get generated. This pr aims to fix that issue until we get https