### PR TITLE
Redirect HTTP to HTTPS

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -33,6 +33,10 @@ func New() (*Server, error) {
 	return s, nil
 }
 
+func redirectToHttps(w http.ResponseWriter, r *http.Request) {
+    http.Redirect(w, r, "https://" + r.Host + r.RequestURI, http.StatusMovedPermanently)
+}
+
 // ListenAndServe will listen for requests
 func (s *Server) ListenAndServe(errChan chan error) error {
 	portToUse := config.GetServerPort()
@@ -43,6 +47,9 @@ func (s *Server) ListenAndServe(errChan chan error) error {
 	s.Server = &http.Server{
 		Addr:    net.JoinHostPort(config.GetServerHost(), strconv.Itoa(portToUse)),
 		Handler: s.Router,
+	}
+	if (config.GetMode() == config.MODE_PROD) {
+		s.Server.Handler = http.HandlerFunc(redirectToHttps)
 	}
 
 	logger := s.Logger.With("Address", s.Server.Addr)


### PR DESCRIPTION
Since we now have an SSL certificate for map.theshoeproject.online we can start using https. This pr will ensure that we redirect all HTTP traffic to HTTPS on prod