### PR TITLE
feat: show and hide stories when checked

### DIFF
--- a/ui/src/pages/Admin/AllStories/index.tsx
+++ b/ui/src/pages/Admin/AllStories/index.tsx
@@ -584,9 +584,6 @@ export const AllStories: React.FC = () => {
               {
                 name: "ID",
                 width: "5%",
-                onHeaderClick() {
-                  handleRequestSort("ID");
-                },
                 header: (
                   <div>
                     <Checkbox
@@ -606,6 +603,7 @@ export const AllStories: React.FC = () => {
                 cell: (story) => (
                   <div>
                     <Checkbox
+                      checked={state.selectedRowIds.includes(story.ID)}
                       classes={{
                         root: classes.checkbox,
                         checked: classes.checked,
@@ -718,9 +716,6 @@ export const AllStories: React.FC = () => {
               {
                 name: "ID",
                 width: "5%",
-                onHeaderClick() {
-                  handleRequestSort("ID");
-                },
                 header: (
                   <div>
                     <Checkbox
@@ -732,7 +727,7 @@ export const AllStories: React.FC = () => {
                       indeterminate={indeterminate}
                       onChange={(e) => {
                         e.persist();
-                        handleCheckedAll;
+                        handleCheckedAll();
                       }}
                     />
                   </div>
@@ -740,6 +735,7 @@ export const AllStories: React.FC = () => {
                 cell: (story) => (
                   <div>
                     <Checkbox
+                      checked={state.selectedRowIds.includes(story.ID)}
                       classes={{
                         root: classes.checkbox,
                         checked: classes.checked,

--- a/ui/src/pages/Admin/AllStories/index.tsx
+++ b/ui/src/pages/Admin/AllStories/index.tsx
@@ -39,7 +39,6 @@ import { VisibilitySwitch } from "./VisibilitySwitch";
 const StyledFilter = styled.div`
   width: 100vw;
   margin-top: 1vh;
-  // justify-self: right;
 `;
 
 const StyledButton = styled(Button)`
@@ -385,37 +384,29 @@ export const AllStories: React.FC = () => {
 
   const handleVisibilityButtons = (visibilityType: string) => {
     if (visibilityType === "hide") {
-      mutate(
-        "/api/stories",
-        (prevStories: Story[]) => {
-          return prevStories.map((currStory) =>
-            currStory.is_visible &&
-            state.checkedVisibleStoriesArray.includes(currStory.ID)
-              ? { ...currStory, is_visible: !currStory.is_visible }
-              : currStory
-          );
-        },
-        false
-      );
-
+      state.checkedVisibleStoriesArray.forEach((s) => {
+        const changeEvent = {
+          target: {
+            checked: getStoryByID(s).is_visible ? false : true,
+          },
+        } as React.ChangeEvent<HTMLInputElement>;
+        handleSwitchChange(changeEvent, getStoryByID(s));
+      });
       dispatch({ type: "UNCHECK_STORIES", visibilityCondition: "hide" });
-      //uncheck
-      //dispatch
     } else {
-      mutate(
-        "/api/stories",
-        (prevStories: Story[]) => {
-          return prevStories.map((currStory) =>
-            !currStory.is_visible &&
-            state.checkedHiddenStoriesArray.includes(currStory.ID)
-              ? { ...currStory, is_visible: !currStory.is_visible }
-              : currStory
-          );
-        },
-        false
-      );
+      state.checkedHiddenStoriesArray.forEach((s) => {
+        const changeEvent = {
+          target: {
+            checked: getStoryByID(s).is_visible ? false : true,
+          },
+        } as React.ChangeEvent<HTMLInputElement>;
+        handleSwitchChange(changeEvent, getStoryByID(s));
+      });
       dispatch({ type: "UNCHECK_STORIES", visibilityCondition: "show" });
     }
+  };
+  const getStoryByID = (id: number) => {
+    return allStories.find((s) => s.ID === id);
   };
   const handleCheckedAll = () => {
     dispatch({ type: "HANDLE_CHECKED_ALL", rows: allStories });
@@ -461,7 +452,6 @@ export const AllStories: React.FC = () => {
     }
     return 0;
   };
-
   const indeterminate =
     state.selectedRowIds.length > 0 &&
     state.selectedRowIds.length !== allStories.length;
@@ -901,19 +891,44 @@ export const AllStories: React.FC = () => {
                         root: classes.checkbox,
                         checked: classes.checked,
                       }}
-                      checked={state.selectedRowIds.length > 0}
+                      checked={
+                        state.checkedVisibleStoriesArray.length +
+                          state.checkedHiddenStoriesArray.length >
+                        0
+                      }
                       indeterminate={indeterminate}
                       onChange={(e) => {
                         e.persist();
                         handleCheckedAll();
                       }}
                     />
+                    <Button
+                      onClick={(e) => handleClick(e, "checkbox")}
+                      variant="contained"
+                      color="primary"
+                      style={{
+                        padding: "0px",
+                        minWidth: "1vw",
+                        paddingRight: "-20px",
+                        boxShadow: "none",
+                        backgroundColor: colors.white,
+                      }}
+                    >
+                      <ExpandMoreIcon
+                        style={{
+                          color: colors.black,
+                        }}
+                      />
+                    </Button>
                   </div>
                 ),
                 cell: (story) => (
                   <div>
                     <Checkbox
-                      checked={state.selectedRowIds.includes(story.ID)}
+                      checked={
+                        state.checkedHiddenStoriesArray.includes(story.ID) ||
+                        state.checkedVisibleStoriesArray.includes(story.ID)
+                      }
                       classes={{
                         root: classes.checkbox,
                         checked: classes.checked,

--- a/ui/src/pages/Admin/AllStories/reducer.ts
+++ b/ui/src/pages/Admin/AllStories/reducer.ts
@@ -158,9 +158,9 @@ export function allStoriesReducer(state: State, action: Action): State {
       return {
         ...state,
         selectedRowIds:
-          state.selectedRowIds.length === state.tableData.length
-            ? []
-            : state.tableData.map((story) => story.ID),
+          state.selectedRowIds.length === 0
+            ? state.tableData.map((story) => story.ID)
+            : [],
       };
     }
     case "HANDLE_CHECKED": {

--- a/ui/src/pages/Admin/AllStories/reducer.ts
+++ b/ui/src/pages/Admin/AllStories/reducer.ts
@@ -99,7 +99,6 @@ export function allStoriesReducer(state: State, action: Action): State {
       }
     }
     case "HANDLE_POPOVER_CHECKED": {
-      console.log(state.checkedVisibleStoriesArray.length);
       if (action.visibilityCondition === "all") {
         return {
           ...state,

--- a/ui/src/pages/Admin/AllStories/reducer.ts
+++ b/ui/src/pages/Admin/AllStories/reducer.ts
@@ -11,6 +11,7 @@ type VisibilityType = {
 
 export interface State {
   anchorEl: HTMLButtonElement | null;
+  popoverAnchorEl: HTMLButtonElement | null;
   tabValue: number;
   search: string;
   visibleState: number[];
@@ -25,11 +26,13 @@ export interface State {
   orderBy: string;
   tags: string[];
   filterState: FilterState;
+  checkedVisibleStoriesArray: number[];
+  checkedHiddenStoriesArray: number[];
 }
 
 export type Action =
   | { type: "SWITCH_TAB"; id: number }
-  | { type: "SET_ANCHOR"; click: HTMLButtonElement }
+  | { type: "SET_ANCHOR"; click: HTMLButtonElement; popoverType: string }
   | { type: "HANDLE_SWITCH_CHANGE"; e: React.ChangeEvent; story: StoryView }
   | { type: "INITIALIZE_AFTER_API"; rows: StoryView[] }
   | { type: "INITIALIZE_AFTER_TAGS_API"; rows: string[] }
@@ -44,8 +47,9 @@ export type Action =
       type: "HANDLE_SEARCH/FILTER";
       newFilterState: FilterState;
       newSearch: string;
-    };
-
+    }
+  | { type: "HANDLE_POPOVER_CHECKED"; visibilityCondition: string }
+  | { type: "UNCHECK_STORIES"; visibilityCondition: string };
 export const INIT_STATE: State = {
   anchorEl: null,
   tabValue: 0,
@@ -68,6 +72,9 @@ export const INIT_STATE: State = {
     },
     tags: {},
   },
+  popoverAnchorEl: null,
+  checkedVisibleStoriesArray: [],
+  checkedHiddenStoriesArray: [],
 };
 
 export function allStoriesReducer(state: State, action: Action): State {
@@ -79,11 +86,60 @@ export function allStoriesReducer(state: State, action: Action): State {
       };
     }
     case "SET_ANCHOR": {
-      return {
-        ...state,
-        anchorEl: action.click,
-      };
+      if (action.popoverType === "filter") {
+        return {
+          ...state,
+          anchorEl: action.click,
+        };
+      } else {
+        return {
+          ...state,
+          popoverAnchorEl: action.click,
+        };
+      }
     }
+    case "HANDLE_POPOVER_CHECKED": {
+      console.log(state.checkedVisibleStoriesArray.length);
+      if (action.visibilityCondition === "all") {
+        return {
+          ...state,
+          selectedRowIds: state.tableData.map((story) => story.ID),
+          checkedVisibleStoriesArray: state.visibleTableState
+            .filter((story) => story.is_visible)
+            .map((story) => story.ID),
+          checkedHiddenStoriesArray: state.visibleTableState
+            .filter((story) => !story.is_visible)
+            .map((story) => story.ID),
+        };
+      } else if (action.visibilityCondition === "visible") {
+        return {
+          ...state,
+          selectedRowIds: state.tableData.map((story) => {
+            if (story.is_visible) {
+              return story.ID;
+            }
+          }),
+          checkedVisibleStoriesArray: state.visibleTableState
+            .filter((story) => story.is_visible)
+            .map((story) => story.ID),
+          checkedHiddenStoriesArray: INIT_STATE.checkedHiddenStoriesArray,
+        };
+      } else {
+        return {
+          ...state,
+          selectedRowIds: state.tableData.map((story) => {
+            if (!story.is_visible) {
+              return story.ID;
+            }
+          }),
+          checkedHiddenStoriesArray: state.visibleTableState
+            .filter((story) => !story.is_visible)
+            .map((story) => story.ID),
+          checkedVisibleStoriesArray: INIT_STATE.checkedVisibleStoriesArray,
+        };
+      }
+    }
+
     case "HANDLE_SWITCH_CHANGE": {
       const changedVisibilityContainsID = state.changedVisibility.some(
         (e) => e.ID === action.story.ID
@@ -153,31 +209,90 @@ export function allStoriesReducer(state: State, action: Action): State {
         },
       };
     }
-
-    case "HANDLE_CHECKED_ALL": {
-      return {
-        ...state,
-        selectedRowIds:
-          state.selectedRowIds.length === 0
-            ? state.tableData.map((story) => story.ID)
-            : [],
-      };
-    }
-    case "HANDLE_CHECKED": {
-      const target = action.e.target as HTMLInputElement;
-
-      if (target.checked) {
+    case "UNCHECK_STORIES": {
+      if (action.visibilityCondition === "hide") {
         return {
           ...state,
-          selectedRowIds: [...state.selectedRowIds, action.story.ID],
+          selectedRowIds: state.selectedRowIds.filter(
+            (s) => !state.visibleState.includes(s)
+          ),
+          checkedVisibleStoriesArray: INIT_STATE.checkedVisibleStoriesArray,
         };
       } else {
         return {
           ...state,
-          selectedRowIds: state.selectedRowIds.filter(
-            (e) => e !== action.story.ID
+          selectedRowIds: state.selectedRowIds.filter((s) =>
+            state.visibleState.includes(s)
           ),
+          checkedHiddenStoriesArray: INIT_STATE.checkedHiddenStoriesArray,
         };
+      }
+    }
+    case "HANDLE_CHECKED_ALL": {
+      if (state.selectedRowIds.length === 0) {
+        return {
+          ...state,
+          selectedRowIds: state.tableData.map((story) => story.ID),
+          checkedVisibleStoriesArray: state.visibleTableState
+            .filter((story) => story.is_visible)
+            .map((story) => story.ID),
+          checkedHiddenStoriesArray: state.visibleTableState
+            .filter((story) => !story.is_visible)
+            .map((story) => story.ID),
+        };
+      } else {
+        return {
+          ...state,
+          selectedRowIds: INIT_STATE.selectedRowIds,
+          checkedHiddenStoriesArray: INIT_STATE.checkedHiddenStoriesArray,
+          checkedVisibleStoriesArray: INIT_STATE.checkedVisibleStoriesArray,
+        };
+      }
+    }
+    case "HANDLE_CHECKED": {
+      const target = action.e.target as HTMLInputElement;
+      if (target.checked) {
+        if (action.story.is_visible) {
+          return {
+            ...state,
+            selectedRowIds: [...state.selectedRowIds, action.story.ID],
+            checkedVisibleStoriesArray: [
+              ...state.checkedVisibleStoriesArray,
+              action.story.ID,
+            ],
+          };
+        } else {
+          return {
+            ...state,
+            selectedRowIds: [...state.selectedRowIds, action.story.ID],
+            checkedHiddenStoriesArray: [
+              ...state.checkedHiddenStoriesArray,
+              action.story.ID,
+            ],
+          };
+        }
+      } else {
+        if (!action.story.is_visible) {
+          return {
+            ...state,
+            selectedRowIds: state.selectedRowIds.filter(
+              (e) => e !== action.story.ID
+            ),
+            checkedHiddenStoriesArray: state.checkedHiddenStoriesArray.filter(
+              (id) => id !== action.story.ID
+            ),
+          };
+        } else {
+          return {
+            ...state,
+            selectedRowIds: state.selectedRowIds.filter(
+              (e) => e !== action.story.ID
+            ),
+            checkedVisibleStoriesArray: state.checkedVisibleStoriesArray.filter(
+              (id) => id !== action.story.ID
+            ),
+          };
+        }
       }
     }
     case "SET_ORDERING": {


### PR DESCRIPTION
### Description
Give user the option to show and hide stories on batch when they select the checkmarks on the left-hand side. The multiselect frames in Figma can be found [here](https://www.figma.com/file/uVqnweL2ApqvPHWzQYmZ1t/Dashboard?node-id=1159%3A2297).
Essentially, checked boxes are now stored in two separate array states, `checkedVisibleStoriesArray` and `checkedHiddenStoriesArray`, when the user selects to either show or hide, we call `handleSwitchChange` on every single story in the respective array and dispatch the appropriate action + mutation. Please test to see if the behaviour is as you would expect. 

### Demo 

https://user-images.githubusercontent.com/19617248/116019997-6ab88880-a613-11eb-800c-473d48e04273.mov

#### To-do

- Add confirmation toast when stories are hidden or shown
- Fix the styling :apple:

