### PR TITLE
feat: warning pages on close tab and styling changes

### DIFF
--- a/ui/src/pages/Admin/AllStories/index.tsx
+++ b/ui/src/pages/Admin/AllStories/index.tsx
@@ -102,7 +102,7 @@ const StyledSearchBar = styled(SearchBar)`
   }
 `;
 
-const StyledChip = styled(Chip)`
+export const StyledChip = styled(Chip)`
   &&.MuiChip-root {
     color: ${colors.primaryDark2};
     font-family: Poppins;
@@ -111,7 +111,6 @@ const StyledChip = styled(Chip)`
     margin-right: 4px;
     text-transform: capitalize;
   }
-
   &&.MuiChip-colorPrimary {
     background: ${colors.primaryLight3};
   }

--- a/ui/src/pages/Admin/AllStories/index.tsx
+++ b/ui/src/pages/Admin/AllStories/index.tsx
@@ -373,6 +373,17 @@ export const AllStories: React.FC = () => {
     }
   }, [allStories, tagOptions]);
 
+  useEffect(() => {
+    window.addEventListener("beforeunload", alertUser);
+    return () => {
+      window.removeEventListener("beforeunload", alertUser);
+    };
+  }, []);
+  const alertUser = (e) => {
+    e.preventDefault();
+    e.returnValue = "";
+  };
+
   const setClickedRow = (rowId: number | undefined) => {
     if (rowId) {
       const story = allStories?.find((story: StoryView) => story.ID === rowId);

--- a/ui/src/pages/Admin/Edit/UploadStory.tsx
+++ b/ui/src/pages/Admin/Edit/UploadStory.tsx
@@ -29,6 +29,7 @@ import { StoryDrawer } from "../../../components";
 import { citiesList } from "../../../data/cities";
 import { colors } from "../../../styles/colors";
 import { device } from "../../../styles/device";
+import { fontSize } from "../../../styles/typography";
 import {
   UploadLabelsText,
   UploadStoriesHeading,
@@ -38,6 +39,17 @@ import { ListboxComponent, renderGroup } from "./Listbox";
 import { get_init_state, uploadStoryReducer } from "./reducer";
 import { StoryProps, TagParameters } from "./types";
 
+const ChangeImageButton = styled(Button)`
+&& {
+  box-shadow: none;
+  background-color: ${colors.primaryDark1};
+  &:active {
+    background-color: ${colors.primaryDark2};
+  }
+  &:hover{
+    background-color: ${colors.primaryDark3};
+  }
+`;
 const StyledGrid = styled(Grid)`
   background-color: ${colors.primaryLight6};
   @media ${device.laptop} {
@@ -61,6 +73,21 @@ const StyledLink = styled.a`
   margin-right: 30px;
 `;
 
+const StyledChip = styled(Chip)`
+  &&.MuiChip-root {
+    color: ${colors.primaryDark2};
+    font-family: Poppins;
+    font-size: ${fontSize.body1};
+    line-height: 150%;
+    margin-right: 4px;
+    text-transform: capitalize;
+    background: ${colors.primaryLight3};
+    .MuiChip-deleteIcon {
+      color: ${colors.primaryDark2} !important;
+    }
+  }
+`;
+
 const StyledContainer = styled.div`
   display: flex;
 `;
@@ -78,6 +105,9 @@ const StyledTextField = styled(TextField)`
     margin-top: 12px;
     .MuiInputLabel-formControl {
       font-family: Poppins !important;
+    }
+    .MuiInputBase-root {
+      font-family: "Poppins";
     }
   }
 `;
@@ -702,9 +732,9 @@ export const UploadStory: React.FC<StoryProps> = ({
                   value={state.tagArray ? state.tagArray : [""]}
                   renderTags={(value, getTagProps) =>
                     value.map((option, index) => (
-                      <Chip
+                      <StyledChip
+                        variant="default"
                         key={option}
-                        variant="outlined"
                         label={option}
                         {...getTagProps({ index })}
                       />
@@ -748,7 +778,7 @@ export const UploadStory: React.FC<StoryProps> = ({
                     <UploadLabelsText>Current Image:</UploadLabelsText>
                     <br />
                     <StyledImage src={currentStory.image_url} />
-                    <Button
+                    <ChangeImageButton
                       color="primary"
                       variant="contained"
                       onClick={() =>
@@ -756,7 +786,7 @@ export const UploadStory: React.FC<StoryProps> = ({
                       }
                     >
                       Change Image
-                    </Button>
+                    </ChangeImageButton>
                   </div>
                 )}
               </ImageContainer>


### PR DESCRIPTION
### Description
Add an event listener to the `window` to check when user reloads, closes tab, or wants to navigate back. This prompts this warning (default to google chrome): 
![Screen Shot 2021-04-29 at 3 03 38 PM](https://user-images.githubusercontent.com/19617248/116604658-6aaed600-a8fc-11eb-8092-dbf4a0b24dd7.png)
Closes #314 
Changed the styling of the chip and change image buttons on upload/edit stories.
![image](https://user-images.githubusercontent.com/19617248/116604744-87e3a480-a8fc-11eb-93ee-cc13e2e34a39.png)
![image](https://user-images.githubusercontent.com/19617248/116604760-8ca85880-a8fc-11eb-9a6c-2512f0254b63.png)
Closes #315