### PR TITLE
fix: table row height

### DIFF
--- a/ui/src/components/VirtualizedTable.tsx
+++ b/ui/src/components/VirtualizedTable.tsx
@@ -21,6 +21,12 @@ const useVirtualizedTableStyles = makeStyles({
       fontSize: fontSize.subtitle,
       lineHeight: "120%",
       marginRight: "none",
+      height: "auto",
+      "& div": {
+        whiteSpace: "normal",
+        overflow: "hidden",
+        marginTop: "2px",
+      },
     },
     "& .topLeftGrid, & .topRightGrid": {
       border: "none",
@@ -95,6 +101,7 @@ export function VirtualizedTable({
             width={width}
             height={height}
             maxHeight={800}
+            rowHeight={70}
             fixedRowCount={1}
             style={{ tableLayout: "fixed", backgroundColor: colors.white }}
           />


### PR DESCRIPTION
Increased the table row height for all rows globally in order to show two lines of tags.
![image](https://user-images.githubusercontent.com/19617248/116791303-577c4180-aa87-11eb-8d27-f574960b9864.png)
Closes #328 