### PR TITLE
Bug fix: filter on map page only shows countries from visible stories

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,6 @@ require (
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/viper v1.7.1
 	github.com/stretchr/testify v1.6.1
-	github.com/thoas/go-funk v0.7.0
 	github.com/valyala/fasthttp v1.15.1 // indirect
 	github.com/xhit/go-str2duration/v2 v2.0.0
 	go.uber.org/zap v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -445,8 +445,6 @@ github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
-github.com/thoas/go-funk v0.7.0 h1:GmirKrs6j6zJbhJIficOsz2aAI7700KsU/5YrdHRM1Y=
-github.com/thoas/go-funk v0.7.0/go.mod h1:+IWnUfUmFO1+WVYQWQtIJHeRRdaIyyYglZN7xzUPe4Q=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=

--- a/restapi/authors.go
+++ b/restapi/authors.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/biter777/countries"
 	"github.com/go-chi/render"
-	"github.com/thoas/go-funk"
 	"github.com/uwblueprint/shoe-project/internal/database/models"
 	"github.com/uwblueprint/shoe-project/restapi/rest"
 )
@@ -37,24 +36,14 @@ func (api api) CreateAuthors(w http.ResponseWriter, r *http.Request) render.Rend
 }
 
 func (api api) ReturnAuthorOriginCountries(w http.ResponseWriter, r *http.Request) render.Renderer {
-	var authors []models.Author
-	countries := make(map[string]bool)
+	var countries []string
 
-	err := api.database.Find(&authors).Error
-	if err != nil {
-		return rest.ErrInternal(api.logger, err)
-	}
+    err := api.database.Table("stories").Where("is_visible = true").Distinct().Pluck("author_country", &countries).Error
+    if err != nil {
+        return rest.ErrInternal(api.logger, err)
+    }
 
-	for _, entry := range authors {
-		if entry.OriginCountry != "" {
-			countries[entry.OriginCountry] = true
-		} else {
-			api.logger.Debug("Empty origin country")
-		}
-	}
+    sort.Strings(countries)
 
-	listOfCountries := funk.Keys(countries)
-	sort.Strings(listOfCountries.([]string))
-
-	return rest.JSONStatusOK(listOfCountries)
+    return rest.JSONStatusOK(countries)
 }

--- a/restapi/authors.go
+++ b/restapi/authors.go
@@ -37,7 +37,7 @@ func (api api) CreateAuthors(w http.ResponseWriter, r *http.Request) render.Rend
 
 func (api api) ReturnAuthorOriginCountries(w http.ResponseWriter, r *http.Request) render.Renderer {
 	var countries []string
-
+	// SELECT DISTINCT author_country from stories where is_visble=true
     err := api.database.Table("stories").Where("is_visible = true").Distinct().Pluck("author_country", &countries).Error
     if err != nil {
         return rest.ErrInternal(api.logger, err)

--- a/restapi/endpoints_test.go
+++ b/restapi/endpoints_test.go
@@ -345,6 +345,24 @@ func (suite *endpointTestSuite) TestGetAllStories() {
 	response.Object().Value("payload").Array().Element(1).Object().Value("current_city").Equal("Toronto")
 	response.Object().Value("payload").Array().Element(1).Object().Value("tags").Array().Empty()
 }
+
+func (suite *endpointTestSuite) TestGetVisibleCountries() {
+    jsonStories := GetStoriesToTest()
+    jsonAuthors := GetAuthorsToTest()
+
+    suite.db.Create(&jsonAuthors)
+    suite.db.Create(&jsonStories)
+
+    var response = suite.endpoint.GET("/authors/origin_countries").
+        Expect().
+        Status(http.StatusOK).JSON()
+        
+    response.Object().Value("payload").Array().Length().Equal(3)
+    response.Object().Value("payload").Array().Element(0).Equal("Canada")
+    response.Object().Value("payload").Array().Element(1).Equal("France")
+    response.Object().Value("payload").Array().Element(2).Equal("USA")
+}
+
 func (suite *endpointTestSuite) TestGetAllInvisibleStories() {
 
 	jsonStories := GetStoriesToTest()


### PR DESCRIPTION
## Closes #341 

## Description
- Current behaviour: The filter on the homepage page currently shows countries that are attached to stories that are not visible on the map (ie. you can filter by the country, but when you do nothing shows up on the map)
- Created a fix + ran a short test