### PR TITLE
fix iconAnchor for individual pin

### DIFF
--- a/ui/src/components/Pin.tsx
+++ b/ui/src/components/Pin.tsx
@@ -68,7 +68,7 @@ export function Pin({
   const icon = new L.Icon({
     iconUrl: state === PinState.Unfocused ? unfocused : resting,
     iconRetinaUrl: state === PinState.Unfocused ? unfocused : resting,
-    iconAnchor: state === PinState.Selected ? [29, 70] : [25, 61],
+    iconAnchor: state === PinState.Selected ? [24, 57] : [19.5, 48],
     popupAnchor: [234, -100],
     shadowUrl: null,
     shadowSize: null,


### PR DESCRIPTION
Currently when zoomed out and individual pin is showing (not a pin cluster), the pin does not stay in its original position. For example in the pic the story city is Toronto, but it did not stay at Toronto when zoomed out.

Before:
![image](https://user-images.githubusercontent.com/37384882/116834254-369d1480-ab8b-11eb-9110-871965000c94.png)

Now:
![image](https://user-images.githubusercontent.com/37384882/116834344-a1e6e680-ab8b-11eb-86be-ab86dafb900f.png)

